### PR TITLE
feat: Extract Alert Engine WS connector from the main repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+version: 2.1
+
+# this allows you to use CircleCI's dynamic configuration feature
+setup: true
+
+orbs:
+  gravitee: gravitee-io/gravitee@2.1
+
+# our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
+# some workflow and job will not be triggered for tags (default CircleCI behavior)
+workflows:
+  setup_build:
+    when:
+      not: << pipeline.git.tag >>
+    jobs:
+      - gravitee/setup_plugin-build-config:
+          filters:
+            tags:
+              ignore:
+                - /.*/
+
+  setup_release:
+    when:
+      matches:
+        pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        value: << pipeline.git.tag >>
+    jobs:
+      - gravitee/setup_plugin-release-config:
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^[0-9]+\.[0-9]+\.[0-9]+$/

--- a/gravitee-alert-engine-connector-api/pom.xml
+++ b/gravitee-alert-engine-connector-api/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.ae</groupId>
+        <artifactId>gravitee-alert-engine-connectors</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>gravitee-alert-engine-connectors-api</artifactId>
+    <name>Gravitee.io - Alert Engine - Connectors - API</name>
+
+    <dependencies>
+        <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Gravitee dependencies -->
+        <dependency>
+            <groupId>io.gravitee.plugin</groupId>
+            <artifactId>gravitee-plugin-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/AbstractCommand.java
+++ b/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/AbstractCommand.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.api.command;
+
+import io.gravitee.common.utils.UUID;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public abstract class AbstractCommand implements Command {
+
+    private final String id = UUID.random().toString();
+
+    @Override
+    public String id() {
+        return this.id;
+    }
+}

--- a/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/AlertNotificationCommand.java
+++ b/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/AlertNotificationCommand.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.api.command;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class AlertNotificationCommand extends AbstractCommand {
+
+    private final long timestamp;
+
+    private final String trigger;
+
+    private final String message;
+
+    @JsonCreator
+    public AlertNotificationCommand(
+        @JsonProperty(value = "timestamp", required = true) long timestamp,
+        @JsonProperty(value = "trigger", required = true) String trigger,
+        @JsonProperty(value = "message") String message
+    ) {
+        this.timestamp = timestamp;
+        this.trigger = trigger;
+        this.message = message;
+    }
+
+    @Override
+    public Type type() {
+        return Type.ALERT_NOTIFICATION;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public String getTrigger() {
+        return trigger;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/Command.java
+++ b/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/Command.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.api.command;
+
+import com.fasterxml.jackson.annotation.*;
+import java.io.Serializable;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
+@JsonSubTypes(
+    {
+        @JsonSubTypes.Type(value = NodeDiscoveryCommand.class, name = "NODE_DISCOVERY"),
+        @JsonSubTypes.Type(value = NodeDiscoveryCommand.class, name = "node_discovery"),
+        @JsonSubTypes.Type(value = AlertNotificationCommand.class, name = "ALERT_NOTIFICATION"),
+        @JsonSubTypes.Type(value = AlertNotificationCommand.class, name = "alert_notification"),
+        @JsonSubTypes.Type(value = ResolvePropertyCommand.class, name = "PROPERTY_RESOLVER"),
+        @JsonSubTypes.Type(value = ResolvePropertyCommand.class, name = "property_resolver"),
+    }
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public interface Command extends Serializable {
+    enum Type {
+        NODE_DISCOVERY,
+        ALERT_NOTIFICATION,
+        PROPERTY_RESOLVER,
+    }
+
+    @JsonProperty
+    String id();
+
+    @JsonProperty
+    Type type();
+}

--- a/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/Handler.java
+++ b/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/Handler.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.api.command;
+
+/**
+ * A generic command result handler.
+ *
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ *
+ * @param <T> Type of the result
+ */
+@FunctionalInterface
+public interface Handler<T> {
+    void handle(T result);
+}

--- a/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/NodeDiscoveryCommand.java
+++ b/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/NodeDiscoveryCommand.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.api.command;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NodeDiscoveryCommand extends AbstractCommand {
+
+    private final String action;
+
+    private final String member;
+
+    private final String endpoint;
+
+    @JsonCreator
+    public NodeDiscoveryCommand(
+        @JsonProperty(value = "action", required = true) String action,
+        @JsonProperty(value = "member", required = true) String member,
+        @JsonProperty(value = "endpoint", required = true) String endpoint
+    ) {
+        this.action = action;
+        this.member = member;
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public Type type() {
+        return Type.NODE_DISCOVERY;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public String getMember() {
+        return member;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+}

--- a/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/ResolvePropertyCommand.java
+++ b/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/ResolvePropertyCommand.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.api.command;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ResolvePropertyCommand extends AbstractCommand {
+
+    private final String source;
+
+    private final Map<String, String> properties;
+
+    @JsonCreator
+    public ResolvePropertyCommand(
+        @JsonProperty(value = "source", required = true) String source,
+        @JsonProperty(value = "properties", required = true) Map<String, String> properties
+    ) {
+        this.source = source;
+        this.properties = properties;
+    }
+
+    @Override
+    public Type type() {
+        return Type.PROPERTY_RESOLVER;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+}

--- a/gravitee-alert-engine-connector-core/pom.xml
+++ b/gravitee-alert-engine-connector-core/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.ae</groupId>
+        <artifactId>gravitee-alert-engine-connectors</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>gravitee-alert-engine-connectors-core</artifactId>
+    <name>Gravitee.io - Alert Engine - Connectors - Core</name>
+
+    <dependencies>
+        <!-- Gravitee dependencies -->
+        <dependency>
+            <groupId>io.gravitee.plugin</groupId>
+            <artifactId>gravitee-plugin-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/gravitee-alert-engine-connector-core/src/main/java/io/gravitee/ae/connector/core/ContextBuilder.java
+++ b/gravitee-alert-engine-connector-core/src/main/java/io/gravitee/ae/connector/core/ContextBuilder.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.core;
+
+import io.gravitee.alert.api.event.Context;
+import io.gravitee.node.api.Node;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ContextBuilder {
+
+    private final Node node;
+
+    public ContextBuilder(Node node) {
+        this.node = node;
+    }
+
+    public Context build() {
+        final Context context = new Context();
+
+        // Try to get information from Node.
+        context.put(Context.CONTEXT_NODE_ID, node.id());
+        context.put(Context.CONTEXT_NODE_APPLICATION, node.application());
+        context.put(Context.CONTEXT_NODE_HOSTNAME, node.hostname());
+        context.put(Context.CONTEXT_INSTALLATION, (String) node.metadata().get(Node.META_INSTALLATION));
+
+        return context;
+    }
+}

--- a/gravitee-alert-engine-connector-core/src/main/java/io/gravitee/ae/connector/core/probe/AlertProbe.java
+++ b/gravitee-alert-engine-connector-core/src/main/java/io/gravitee/ae/connector/core/probe/AlertProbe.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.core.probe;
+
+import io.gravitee.node.api.healthcheck.Probe;
+import io.gravitee.node.api.healthcheck.Result;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class AlertProbe implements Probe {
+
+    private AtomicLong droppedEvents = new AtomicLong(0);
+
+    private boolean healthy = true;
+
+    private boolean ready = false;
+
+    private Throwable lastError;
+
+    @Override
+    public String id() {
+        return "alert-engine";
+    }
+
+    @Override
+    public boolean isVisibleByDefault() {
+        return false;
+    }
+
+    @Override
+    public CompletionStage<Result> check() {
+        Result result;
+
+        if (!ready) {
+            result = Result.notReady();
+        } else {
+            if (healthy) {
+                result = Result.healthy("Ok (total dropped events since startup [%s])", droppedEvents);
+            } else {
+                if (lastError != null) {
+                    result = Result.unhealthy("%s (total dropped events since startup [%s])", lastError.getMessage(), droppedEvents);
+                } else {
+                    result = Result.unhealthy("Error (total dropped events since startup [%s])", droppedEvents);
+                }
+            }
+        }
+
+        return CompletableFuture.completedFuture(result);
+    }
+
+    public void addDroppedEvents(int count) {
+        this.droppedEvents.addAndGet(count);
+    }
+
+    public void setReady() {
+        this.ready = true;
+    }
+
+    public void setHealthy() {
+        this.healthy = true;
+    }
+
+    public void setUnhealthy() {
+        this.healthy = false;
+    }
+
+    public void setLastError(Throwable throwable) {
+        this.lastError = throwable;
+    }
+
+    public void setUnhealthy(int count, Throwable throwable) {
+        this.addDroppedEvents(count);
+        this.setLastError(throwable);
+        this.setUnhealthy();
+    }
+}

--- a/gravitee-alert-engine-connector-core/src/main/java/io/gravitee/ae/connector/core/spring/CoreConnectorConfiguration.java
+++ b/gravitee-alert-engine-connector-core/src/main/java/io/gravitee/ae/connector/core/spring/CoreConnectorConfiguration.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.core.spring;
+
+import io.gravitee.ae.connector.core.ContextBuilder;
+import io.gravitee.ae.connector.core.probe.AlertProbe;
+import io.gravitee.node.api.Node;
+import io.gravitee.node.api.healthcheck.ProbeManager;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class CoreConnectorConfiguration {
+
+    @Bean
+    public ContextBuilder contextBuilder(Node node) {
+        return new ContextBuilder(node);
+    }
+
+    @Bean
+    public AlertProbe alertProbe(ProbeManager probeManager) {
+        final AlertProbe alertProbe = new AlertProbe();
+        probeManager.register(alertProbe);
+
+        return alertProbe;
+    }
+}

--- a/gravitee-alert-engine-connector-ws/pom.xml
+++ b/gravitee-alert-engine-connector-ws/pom.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.ae</groupId>
+        <artifactId>gravitee-alert-engine-connectors</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>gravitee-alert-engine-connectors-ws</artifactId>
+    <name>Gravitee.io - Alert Engine - Connectors - Websocket Support</name>
+
+    <properties>
+        <!-- Property used by the publication job in CI-->
+        <publish-folder-path>graviteeio-ae/plugins/connectors</publish-folder-path>
+    </properties>
+
+    <dependencies>
+        <!-- GraviteeSource dependencies -->
+        <dependency>
+            <groupId>io.gravitee.ae</groupId>
+            <artifactId>gravitee-alert-engine-connectors-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.ae</groupId>
+            <artifactId>gravitee-alert-engine-connectors-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-management</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Gravitee dependencies -->
+        <dependency>
+            <groupId>io.gravitee.plugin</groupId>
+            <artifactId>gravitee-plugin-api</artifactId>
+            <version>${gravitee-plugin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Vert.x -->
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-circuit-breaker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Spring dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Unit Tests -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>3.1.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-unit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <finalName>gravitee-ae-connectors-ws-${pom.version}</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <descriptors>
+                        <descriptor>src/main/assembly/plugin-assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-plugin-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-alert-engine-connector-ws/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-alert-engine-connector-ws/src/main/assembly/plugin-assembly.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+	<id>plugin</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<!-- Include the main plugin Jar file -->
+	<files>
+		<file>
+			<source>${project.build.directory}/${project.build.finalName}.jar</source>
+		</file>
+	</files>
+
+	<!-- Finally include plugin dependencies -->
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>lib</outputDirectory>
+			<useProjectArtifact>false</useProjectArtifact>
+		</dependencySet>
+	</dependencySets>
+</assembly>

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/AbstractConnector.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/AbstractConnector.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws;
+
+import io.gravitee.ae.connector.ws.configuration.ConnectorConfiguration;
+import io.gravitee.ae.connector.ws.configuration.Engine;
+import io.gravitee.common.component.AbstractLifecycleComponent;
+import io.gravitee.common.http.HttpHeaders;
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.Assert;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public abstract class AbstractConnector<T> extends AbstractLifecycleComponent<T> {
+
+    private final Logger logger = LoggerFactory.getLogger(AbstractConnector.class);
+    protected HttpClient httpClient;
+
+    @Autowired
+    protected Vertx vertx;
+
+    @Value("${alerts.alert-engine.enabled:false}")
+    protected boolean enabled;
+
+    @Value("${alerts.alert-engine.ws.discovery:true}")
+    protected boolean discovery;
+
+    @Autowired
+    protected ConnectorConfiguration connectorConfiguration;
+
+    @Override
+    protected void doStop() throws Exception {
+        if (httpClient != null) {
+            try {
+                httpClient.close();
+            } catch (IllegalStateException ise) {
+                logger.warn(ise.getMessage());
+            }
+        }
+    }
+
+    public abstract Future<Void> writeTextMessage(String text);
+
+    protected void initHttpClient(Engine engine) {
+        Assert.notNull(engine, "Engine can not be null");
+        Endpoint endpoint = engine.nextEndpoint();
+        httpClient = vertx.createHttpClient(engine.getHttpClientOptions(endpoint));
+    }
+
+    protected MultiMap getDefaultHeaders(Engine engine) {
+        MultiMap headers = HeadersMultiMap.httpHeaders();
+
+        // Read configuration to authenticate calls to Elasticsearch (basic authentication only)
+        if (engine.getSecurity().getUsername() != null) {
+            String basicAuthorizationHeader =
+                this.initEncodedAuthorization(engine.getSecurity().getUsername(), engine.getSecurity().getPassword());
+            headers.set(HttpHeaders.AUTHORIZATION, basicAuthorizationHeader);
+        }
+
+        return headers;
+    }
+
+    protected String initEncodedAuthorization(final String username, final String password) {
+        final String auth = username + ':' + password;
+        final String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + encodedAuth;
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/Endpoint.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/Endpoint.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class Endpoint {
+
+    private final String url;
+
+    public Endpoint(String url) {
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public boolean isRemovable() {
+        return false;
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/HttpConnector.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/HttpConnector.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws;
+
+import io.gravitee.ae.connector.ws.configuration.Engine;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class HttpConnector extends AbstractConnector<HttpConnector> {
+
+    private final Logger logger = LoggerFactory.getLogger(HttpConnector.class);
+
+    private final Engine engine;
+    private final String path;
+
+    public HttpConnector(Engine engine, String path) {
+        this.engine = engine;
+        this.path = path;
+    }
+
+    @Override
+    protected void doStart() {
+        if (enabled) {
+            logger.info("AlertEngine connector is enabled. Starting http connector.");
+            initHttpClient(engine);
+            logger.info("Channel is ready to send data to Alert Engine through http");
+        } else {
+            logger.info("AlertEngine connector is disabled.");
+        }
+    }
+
+    @Override
+    public Future<Void> writeTextMessage(String text) {
+        final Promise<Void> promise = Promise.promise();
+
+        if (httpClient != null) {
+            RequestOptions requestOptions = new RequestOptions()
+                .setURI(path)
+                .setHeaders(getDefaultHeaders(engine))
+                .setMethod(HttpMethod.POST)
+                .setTimeout(connectorConfiguration.getRequestTimeout());
+
+            httpClient
+                .request(requestOptions)
+                .onFailure(promise::fail)
+                .onSuccess(httpClientRequest -> {
+                    // Connection is made, lets continue.
+                    httpClientRequest
+                        .send(Buffer.buffer(text))
+                        .onFailure(promise::fail)
+                        .onSuccess(httpResponse -> {
+                            if (httpResponse.statusCode() >= 200 && httpResponse.statusCode() <= 299) {
+                                promise.complete();
+                                logger.debug("Events successfully sent.");
+                            } else {
+                                promise.fail("Unable to send events. Server replies with status " + httpResponse.statusCode());
+                            }
+                        });
+                });
+        } else {
+            promise.fail("The connector is not yet ready");
+        }
+
+        return promise.future();
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WebSocketConnector.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WebSocketConnector.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws;
+
+import io.gravitee.ae.connector.api.command.Command;
+import io.gravitee.ae.connector.ws.command.CommandHandlerManager;
+import io.gravitee.ae.connector.ws.configuration.Engine;
+import io.gravitee.ae.connector.ws.listener.ListenerManager;
+import io.gravitee.alert.api.event.EventProducer;
+import io.gravitee.alert.api.trigger.TriggerProvider;
+import io.gravitee.node.api.Node;
+import io.vertx.circuitbreaker.CircuitBreaker;
+import io.vertx.circuitbreaker.CircuitBreakerOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketConnectOptions;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.jackson.DatabindCodec;
+import java.io.IOException;
+import java.net.URI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class WebSocketConnector extends AbstractConnector<WebSocketConnector> {
+
+    private final Logger logger = LoggerFactory.getLogger(WebSocketConnector.class);
+
+    private static final long PING_HANDLER_DELAY = 5000;
+
+    @Autowired
+    private ListenerManager listenerManager;
+
+    @Autowired
+    private Node node;
+
+    private WebSocket webSocket;
+    private long pongHandlerId;
+    private CircuitBreaker circuitBreaker;
+    private final Engine engine;
+    private final String path;
+
+    @Autowired
+    private CommandHandlerManager commandHandlerManager;
+
+    public WebSocketConnector(Engine engine, String path) {
+        this.engine = engine;
+        this.path = path;
+    }
+
+    @Override
+    protected void doStart() {
+        if (enabled) {
+            logger.info("AlertEngine connector is enabled. Starting WS connector.");
+
+            circuitBreaker =
+                CircuitBreaker.create(
+                    "alert-engine-event-producer",
+                    vertx,
+                    new CircuitBreakerOptions().setMaxRetries(Integer.MAX_VALUE).setNotificationAddress(null)
+                );
+
+            // Back-off retry
+            // TODO use jitter
+            circuitBreaker.retryPolicy(integer -> 5000L);
+
+            connect();
+        } else {
+            logger.info("AlertEngine connector is disabled.");
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+
+        if (pongHandlerId != 0L) {
+            vertx.cancelTimer(pongHandlerId);
+        }
+    }
+
+    private void connect() {
+        circuitBreaker
+            .execute(this::doConnect)
+            .onComplete(event -> {
+                // The connection has been established
+                if (event.succeeded()) {
+                    WebSocketConnector.this.webSocket = event.result();
+
+                    // Initialize ping-pong
+                    // See RFC 6455 Section <a href="https://tools.ietf.org/html/rfc6455#section-5.5.2"
+                    pongHandlerId =
+                        vertx.setPeriodic(
+                            PING_HANDLER_DELAY,
+                            aLong -> webSocket.writePing(Buffer.buffer(node.id() + " - " + node.hostname()))
+                        );
+
+                    if (discovery) {
+                        logger.info("Discovery mode is enabled, listening for alert engine instances...");
+                    }
+
+                    WebSocketConnector.this.webSocket.handler(buffer -> {
+                            final String sCommand = buffer.toString();
+
+                            try {
+                                Command command = DatabindCodec.mapper().readValue(sCommand, Command.class);
+
+                                commandHandlerManager.handle(
+                                    command,
+                                    result -> {
+                                        if (result != null) {
+                                            WebSocketConnector.this.webSocket.writeTextMessage(
+                                                    "reply:" + command.id() + ":" + Json.encode(result)
+                                                );
+                                        }
+                                    }
+                                );
+                            } catch (IOException ioe) {
+                                logger.error("Unexpected error while reading command: {}", sCommand, ioe);
+                            }
+                        });
+
+                    WebSocketConnector.this.webSocket.exceptionHandler(throwable ->
+                            logger.error("An error occurred on the websocket connection", throwable)
+                        );
+
+                    WebSocketConnector.this.webSocket.pongHandler(data -> logger.debug("Get a pong from Alert Engine server"));
+
+                    WebSocketConnector.this.webSocket.closeHandler(event1 -> {
+                            logger.debug("Connection to Alert Engine server has been closed.");
+
+                            if (pongHandlerId != 0L) {
+                                vertx.cancelTimer(pongHandlerId);
+                            }
+
+                            // Release reference to the websocket connection
+                            WebSocketConnector.this.webSocket = null;
+
+                            invokeOnDisconnectionListeners();
+
+                            // How to force to reconnect ?
+                            connect();
+                        });
+
+                    invokeOnConnectionListeners();
+                } else {
+                    // Retry the connection
+                    connect();
+                }
+            });
+    }
+
+    @Override
+    public Future<Void> writeTextMessage(String text) {
+        if (webSocket != null) {
+            if (!webSocket.writeQueueFull()) {
+                return webSocket.writeTextMessage(text);
+            } else {
+                return Future.failedFuture("An alert event has been skipped, write queue full...");
+            }
+        }
+
+        return Future.failedFuture("The connector is not yet ready");
+    }
+
+    private void doConnect(Promise<WebSocket> webSocketPromise) {
+        initHttpClient(engine);
+        Endpoint endpoint = engine.currentEndpoint();
+
+        if (endpoint != null) {
+            URI target = URI.create(endpoint.getUrl());
+
+            WebSocketConnectOptions webSocketConnectOptions = new WebSocketConnectOptions();
+            webSocketConnectOptions.setHeaders(getDefaultHeaders(engine));
+            webSocketConnectOptions.setURI(target.getRawPath() + path);
+
+            httpClient
+                .webSocket(webSocketConnectOptions)
+                .onSuccess(ws -> {
+                    // Re-init endpoint counter
+                    engine.resetEndpointRetryCount(endpoint);
+
+                    logger.info("Channel is ready to send data to Alert Engine through websocket from {}", endpoint.getUrl() + path);
+                    webSocketPromise.complete(ws);
+                })
+                .onFailure(throwable -> {
+                    logger.error(
+                        "An error occurred while trying to connect to the alert engine: {} [{} times]",
+                        throwable.getMessage(),
+                        engine.getEndpointRetryCount(endpoint)
+                    );
+                    webSocketPromise.fail(throwable);
+
+                    // Force the HTTP client to close after a defect
+                    httpClient.close();
+                });
+        }
+    }
+
+    private void invokeOnConnectionListeners() {
+        if (path.equals(WsTriggerProvider.WS_TRIGGER_PATH)) {
+            listenerManager
+                .getListeners(TriggerProvider.OnConnectionListener.class)
+                .forEach(TriggerProvider.OnConnectionListener::doOnConnect);
+        } else if (path.equals(WsEventProducer.WS_EVENT_PATH)) {
+            listenerManager.getListeners(EventProducer.OnConnectionListener.class).forEach(EventProducer.OnConnectionListener::doOnConnect);
+        }
+    }
+
+    private void invokeOnDisconnectionListeners() {
+        if (path.equals(WsTriggerProvider.WS_TRIGGER_PATH)) {
+            listenerManager
+                .getListeners(TriggerProvider.OnDisconnectionListener.class)
+                .forEach(TriggerProvider.OnDisconnectionListener::doOnDisconnect);
+        } else if (path.equals(WsEventProducer.WS_EVENT_PATH)) {
+            listenerManager
+                .getListeners(EventProducer.OnDisconnectionListener.class)
+                .forEach(EventProducer.OnDisconnectionListener::doOnDisconnect);
+        }
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsConnectorPlugin.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsConnectorPlugin.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Component
+public class WsConnectorPlugin {}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsEventProducer.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsEventProducer.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.ae.connector.core.ContextBuilder;
+import io.gravitee.ae.connector.core.probe.AlertProbe;
+import io.gravitee.ae.connector.ws.configuration.ConnectorConfiguration;
+import io.gravitee.ae.connector.ws.configuration.Engine;
+import io.gravitee.ae.connector.ws.listener.ListenerManager;
+import io.gravitee.alert.api.event.*;
+import io.gravitee.node.api.healthcheck.ProbeManager;
+import io.reactivex.BackpressureStrategy;
+import io.reactivex.Flowable;
+import io.reactivex.FlowableEmitter;
+import io.reactivex.schedulers.Schedulers;
+import io.vertx.core.impl.ConcurrentHashSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class WsEventProducer extends AbstractEventProducer implements ApplicationContextAware {
+
+    private final Logger logger = LoggerFactory.getLogger(WsEventProducer.class);
+
+    private static final int MAX_PENDING_EVENTS = 1000;
+    public static final String WS_EVENT_PATH = "/ws/events";
+    public static final String HTTP_EVENT_PATH = "/http/events";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private AbstractConnector<?> connector;
+
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private ListenerManager listenerManager;
+
+    @Autowired
+    private ContextBuilder contextBuilder;
+
+    @Autowired
+    private ConnectorConfiguration configuration;
+
+    @Autowired
+    ProbeManager probeManager;
+
+    @Autowired
+    private AlertProbe alertProbe;
+
+    private Context context;
+
+    // Keep a copy of events while waiting for producer being started
+    private final Set<Event> pendingEvents = new ConcurrentHashSet<>();
+
+    private FlowableEmitter<Event> eventEmitter;
+
+    @Override
+    public void send(Event event) {
+        if (eventEmitter == null) {
+            if (pendingEvents.size() < MAX_PENDING_EVENTS) {
+                pendingEvents.add(event);
+            } else {
+                // Track dropped events count.
+                alertProbe.addDroppedEvents(1);
+            }
+        } else {
+            eventEmitter.onNext(event);
+        }
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        context = contextBuilder.build();
+
+        final Flowable<Event> bufferedEvents = Flowable
+            .create(this::prepareEventEmitter, BackpressureStrategy.LATEST)
+            .doOnNext(this::copyContextToEvent);
+
+        logger.info("AlertEngine connector is enabled. Starting connector.");
+        Engine defaultEngine = configuration.getDefaultEngine(); // event producer only send the events to the default engine
+
+        if (configuration.isSendEventsOnHttp()) {
+            connector = new HttpConnector(defaultEngine, HTTP_EVENT_PATH);
+            applicationContext.getAutowireCapableBeanFactory().autowireBean(connector);
+            connector.start();
+
+            // Events are buffered to be sent by packets.
+            bufferedEvents
+                .buffer(configuration.getBulkEventsWait(), TimeUnit.MILLISECONDS, configuration.getBulkEventsSize())
+                .doOnNext(this::writeEvents)
+                .onBackpressureDrop(events -> alertProbe.setUnhealthy(events.size(), new RuntimeException("AE is overloaded.")))
+                .observeOn(Schedulers.computation())
+                .subscribe(events -> {}, throwable -> {});
+        } else {
+            connector = new WebSocketConnector(defaultEngine, WS_EVENT_PATH);
+            applicationContext.getAutowireCapableBeanFactory().autowireBean(connector);
+
+            // Listen on connection only makes sense for WebSocket. For now, events are sent 1 by 1 with websocket to keep it backward compatible.
+            listenerManager.addListener(
+                (EventProducer.OnConnectionListener) () ->
+                    bufferedEvents
+                        .doOnNext(this::writeEvent)
+                        .onBackpressureDrop(event -> alertProbe.setUnhealthy(1, new RuntimeException("AE is overloaded.")))
+                        .observeOn(Schedulers.computation())
+                        .subscribe(events -> {}, throwable -> {})
+            );
+            connector.start();
+        }
+
+        alertProbe.setReady();
+    }
+
+    private void prepareEventEmitter(FlowableEmitter<Event> emitter) {
+        this.eventEmitter = emitter;
+        // Now we have internally subscribed, flush the pending events.
+        pendingEvents.forEach(event -> eventEmitter.onNext(event));
+        pendingEvents.clear();
+    }
+
+    private void copyContextToEvent(Event event) {
+        // Copy the property from context to event if not already exists.
+        if (context != null) {
+            if (event.properties() == null && event instanceof DefaultEvent) {
+                ((DefaultEvent) event).setProperties(new HashMap<>());
+            }
+
+            if (event.properties() != null) {
+                context.forEach((k, v) -> event.properties().putIfAbsent(k, v));
+            }
+        }
+    }
+
+    private void writeEvents(List<Event> eventList) {
+        if (!eventList.isEmpty()) {
+            try {
+                connector
+                    .writeTextMessage(mapper.writeValueAsString(eventList))
+                    .onSuccess(aVoid -> alertProbe.setHealthy())
+                    .onFailure(throwable -> {
+                        if (isCurrentlyHealthy()) {
+                            logger.warn("An error occurred trying to send events: {}", throwable.getMessage());
+                        }
+                        alertProbe.setUnhealthy(eventList.size(), throwable);
+                    });
+            } catch (Exception e) {
+                if (isCurrentlyHealthy()) {
+                    logger.error("Unexpected error while writing event", e);
+                }
+                alertProbe.setUnhealthy(eventList.size(), e);
+            }
+        }
+    }
+
+    private boolean isCurrentlyHealthy() {
+        try {
+            return alertProbe.check().toCompletableFuture().get().isHealthy();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private void writeEvent(Event event) {
+        if (event != null) {
+            try {
+                connector
+                    .writeTextMessage(mapper.writeValueAsString(event))
+                    .onSuccess(aVoid -> alertProbe.setHealthy())
+                    .onFailure(throwable -> {
+                        if (isCurrentlyHealthy()) {
+                            logger.warn("An error occurred trying to send event: {}", throwable.getMessage());
+                        }
+                        alertProbe.setUnhealthy(1, throwable);
+                    });
+            } catch (Exception e) {
+                if (isCurrentlyHealthy()) {
+                    logger.error("Unexpected error while writing event", e);
+                }
+                alertProbe.setUnhealthy(1, e);
+            }
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        TimeUnit.MILLISECONDS.sleep(configuration.getBulkEventsWait());
+        connector.stop();
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsTriggerProvider.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsTriggerProvider.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.ae.connector.core.ContextBuilder;
+import io.gravitee.ae.connector.ws.configuration.ConnectorConfiguration;
+import io.gravitee.ae.connector.ws.configuration.Engine;
+import io.gravitee.ae.connector.ws.listener.ListenerManager;
+import io.gravitee.alert.api.condition.StringCondition;
+import io.gravitee.alert.api.event.Context;
+import io.gravitee.alert.api.trigger.AbstractTriggerProvider;
+import io.gravitee.alert.api.trigger.Trigger;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class WsTriggerProvider extends AbstractTriggerProvider implements ApplicationContextAware {
+
+    /**
+     * Logger.
+     */
+    private final Logger logger = LoggerFactory.getLogger(WsTriggerProvider.class);
+
+    public static final String WS_TRIGGER_PATH = "/ws/triggers";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private final Map<Engine, WebSocketConnector> engineWebSocketConnectorMap = new HashMap<>();
+
+    @Autowired
+    private ConnectorConfiguration connectorConfiguration;
+
+    @Autowired
+    private ListenerManager listenerManager;
+
+    @Autowired
+    private ContextBuilder contextBuilder;
+
+    private Context context;
+
+    private ApplicationContext applicationContext;
+
+    @Override
+    public void register(Trigger trigger) {
+        try {
+            final String installationId = context != null ? context.get(Context.CONTEXT_INSTALLATION) : null;
+            if (installationId != null) {
+                // Automatically add a constraint on the installation.
+                final StringCondition installationFilter = StringCondition.equals(Context.CONTEXT_INSTALLATION, installationId).build();
+
+                if (trigger.getFilters() == null) {
+                    trigger.setFilters(new ArrayList<>());
+                } else {
+                    // Create a new collection and make sure we will be able to add the filter (ie: get rid of SingletonList, UnmodifiableList, ...).
+                    trigger.setFilters(new ArrayList<>(trigger.getFilters()));
+                }
+
+                trigger.getFilters().add(installationFilter);
+            }
+
+            String value = mapper.writeValueAsString(trigger);
+            engineWebSocketConnectorMap.forEach((engine, webSocketConnector) -> webSocketConnector.writeTextMessage(value));
+        } catch (JsonProcessingException jpe) {
+            logger.error("Unexpected error while transforming the trigger into a json format", jpe);
+        }
+    }
+
+    @Override
+    public void unregister(Trigger trigger) {
+        try {
+            String value = mapper.writeValueAsString(trigger);
+            engineWebSocketConnectorMap.forEach((engine, webSocketConnector) -> webSocketConnector.writeTextMessage(value));
+        } catch (JsonProcessingException jpe) {
+            logger.error("Unexpected error while transforming the trigger into a json format", jpe);
+        }
+    }
+
+    @Override
+    public void addListener(Listener listener) {
+        listenerManager.addListener(listener);
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        context = contextBuilder.build();
+        logger.info("AlertEngine connector is enabled. Starting connector.");
+        for (Map.Entry<String, Engine> entry : connectorConfiguration.getEngines().entrySet()) {
+            Engine engine = entry.getValue();
+            WebSocketConnector webSocketConnector = new WebSocketConnector(engine, WS_TRIGGER_PATH);
+            applicationContext.getAutowireCapableBeanFactory().autowireBean(webSocketConnector);
+            webSocketConnector.start();
+            engineWebSocketConnectorMap.put(engine, webSocketConnector);
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        for (WebSocketConnector webSocketConnector : engineWebSocketConnectorMap.values()) {
+            webSocketConnector.stop();
+        }
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/CommandHandler.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/CommandHandler.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.command;
+
+import io.gravitee.ae.connector.api.command.Command;
+import io.gravitee.ae.connector.api.command.Handler;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface CommandHandler<T extends Command> {
+    Command.Type getSupportedType();
+
+    void handle(T command, Handler resultHandler);
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/CommandHandlerManager.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/CommandHandlerManager.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.command;
+
+import io.gravitee.ae.connector.api.command.Command;
+import io.gravitee.ae.connector.api.command.Handler;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface CommandHandlerManager {
+    void handle(Command command, Handler resultHandler);
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/CommandHandlerManagerImpl.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/CommandHandlerManagerImpl.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.command;
+
+import io.gravitee.ae.connector.api.command.Command;
+import io.gravitee.ae.connector.api.command.Handler;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class CommandHandlerManagerImpl implements CommandHandlerManager {
+
+    /**
+     * Logger.
+     */
+    private final Logger logger = LoggerFactory.getLogger(CommandHandlerManagerImpl.class);
+
+    @Autowired
+    private List<CommandHandler<? extends Command>> commandHandlers;
+
+    private final Map<Command.Type, CommandHandler> handlers = new HashMap<>();
+
+    @PostConstruct
+    private void init() {
+        this.commandHandlers.forEach(command -> this.handlers.put(command.getSupportedType(), command));
+    }
+
+    @Override
+    public void handle(Command command, Handler resultHandler) {
+        final CommandHandler handler = this.handlers.get(command.type());
+
+        if (handler == null) {
+            logger.error("No handler found to handle command of type {}", command.type());
+        } else {
+            handler.handle(command, resultHandler);
+        }
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/discovery/DynamicEndpoint.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/discovery/DynamicEndpoint.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.command.discovery;
+
+import io.gravitee.ae.connector.ws.Endpoint;
+import java.util.Objects;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class DynamicEndpoint extends Endpoint {
+
+    private final String uuid;
+
+    DynamicEndpoint(String uuid, String url) {
+        super(url);
+        this.uuid = uuid;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public boolean isRemovable() {
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DynamicEndpoint that = (DynamicEndpoint) o;
+        return uuid.equals(that.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid);
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/discovery/NodeDiscoveryCommandHandler.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/discovery/NodeDiscoveryCommandHandler.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.command.discovery;
+
+import io.gravitee.ae.connector.api.command.Command;
+import io.gravitee.ae.connector.api.command.Handler;
+import io.gravitee.ae.connector.api.command.NodeDiscoveryCommand;
+import io.gravitee.ae.connector.ws.command.CommandHandler;
+import io.gravitee.ae.connector.ws.configuration.ConnectorConfiguration;
+import io.gravitee.ae.connector.ws.configuration.Engine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NodeDiscoveryCommandHandler implements CommandHandler<NodeDiscoveryCommand> {
+
+    /**
+     * Logger.
+     */
+    private final Logger logger = LoggerFactory.getLogger(NodeDiscoveryCommandHandler.class);
+
+    private static final String DISCOVERY_NODE_REMOVED = "REMOVE";
+    private static final String DISCOVERY_NODE_CHANGED = "CHANGE";
+
+    @Autowired
+    private ConnectorConfiguration connectorConfiguration;
+
+    @Value("${alerts.alert-engine.ws.discovery:true}")
+    private boolean discovery;
+
+    @Override
+    public Command.Type getSupportedType() {
+        return Command.Type.NODE_DISCOVERY;
+    }
+
+    @Override
+    public void handle(NodeDiscoveryCommand command, Handler resultHandler) {
+        DynamicEndpoint websocketEndpoint = new DynamicEndpoint(command.getMember(), command.getEndpoint());
+
+        if (discovery) {
+            Engine defaultEngine = connectorConfiguration.getDefaultEngine();
+            if (DISCOVERY_NODE_CHANGED.equalsIgnoreCase(command.getAction())) {
+                // Endpoint must be registered only if target does not already exist
+
+                if (defaultEngine.getEndpoints().stream().noneMatch(edpt -> edpt.getUrl().equals(websocketEndpoint.getUrl()))) {
+                    logger.info("An alert engine instance has been discovered at {}", websocketEndpoint.getUrl());
+                    defaultEngine.getEndpoints().add(websocketEndpoint);
+                }
+            } else if (DISCOVERY_NODE_REMOVED.equalsIgnoreCase(command.getAction())) {
+                logger.info("An alert engine instance has been removed from {}", websocketEndpoint.getUrl());
+                defaultEngine.getEndpoints().remove(websocketEndpoint);
+            }
+        }
+
+        resultHandler.handle(null);
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/notification/AlertNotificationCommandHandler.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/notification/AlertNotificationCommandHandler.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.command.notification;
+
+import io.gravitee.ae.connector.api.command.AlertNotificationCommand;
+import io.gravitee.ae.connector.api.command.Command;
+import io.gravitee.ae.connector.api.command.Handler;
+import io.gravitee.ae.connector.ws.command.CommandHandler;
+import io.gravitee.ae.connector.ws.listener.ListenerManager;
+import io.gravitee.alert.api.trigger.TriggerProvider;
+import java.util.function.Consumer;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class AlertNotificationCommandHandler implements CommandHandler<AlertNotificationCommand> {
+
+    @Autowired
+    private ListenerManager listenerManager;
+
+    @Override
+    public Command.Type getSupportedType() {
+        return Command.Type.ALERT_NOTIFICATION;
+    }
+
+    @Override
+    public void handle(AlertNotificationCommand command, Handler resultHandler) {
+        listenerManager
+            .getListeners(TriggerProvider.OnCommandListener.class)
+            .forEach(
+                new Consumer<TriggerProvider.OnCommandListener>() {
+                    @Override
+                    public void accept(TriggerProvider.OnCommandListener listener) {
+                        io.gravitee.alert.api.trigger.command.AlertNotificationCommand alert = new io.gravitee.alert.api.trigger.command.AlertNotificationCommand(
+                            command.getTrigger(),
+                            command.getTimestamp()
+                        );
+
+                        alert.setMessage(command.getMessage());
+
+                        listener.doOnCommand(alert);
+                        resultHandler.handle(null);
+                    }
+                }
+            );
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/resolver/ResolvePropertyCommandHandler.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/resolver/ResolvePropertyCommandHandler.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.command.resolver;
+
+import io.gravitee.ae.connector.api.command.Command;
+import io.gravitee.ae.connector.api.command.Handler;
+import io.gravitee.ae.connector.api.command.ResolvePropertyCommand;
+import io.gravitee.ae.connector.ws.command.CommandHandler;
+import io.gravitee.ae.connector.ws.listener.ListenerManager;
+import io.gravitee.alert.api.trigger.TriggerProvider;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ResolvePropertyCommandHandler implements CommandHandler<ResolvePropertyCommand> {
+
+    @Autowired
+    private ListenerManager listenerManager;
+
+    @Override
+    public Command.Type getSupportedType() {
+        return Command.Type.PROPERTY_RESOLVER;
+    }
+
+    @Override
+    public void handle(ResolvePropertyCommand command, Handler resultHandler) {
+        Optional<TriggerProvider.OnCommandResultListener> optListener = listenerManager
+            .getListeners(TriggerProvider.OnCommandResultListener.class)
+            .stream()
+            .findFirst();
+
+        optListener.ifPresent(listener ->
+            listener.doOnCommand(
+                new io.gravitee.alert.api.trigger.command.ResolvePropertyCommand(command.getProperties()),
+                result -> {
+                    resultHandler.handle(result);
+                }
+            )
+        );
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/spring/CommandConfiguration.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/spring/CommandConfiguration.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.command.spring;
+
+import io.gravitee.ae.connector.ws.command.CommandHandlerManager;
+import io.gravitee.ae.connector.ws.command.CommandHandlerManagerImpl;
+import io.gravitee.ae.connector.ws.command.discovery.NodeDiscoveryCommandHandler;
+import io.gravitee.ae.connector.ws.command.notification.AlertNotificationCommandHandler;
+import io.gravitee.ae.connector.ws.command.resolver.ResolvePropertyCommandHandler;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class CommandConfiguration {
+
+    @Bean
+    public CommandHandlerManager commandHandlerManager() {
+        return new CommandHandlerManagerImpl();
+    }
+
+    @Bean
+    public NodeDiscoveryCommandHandler nodeDiscoveryCommandHandler() {
+        return new NodeDiscoveryCommandHandler();
+    }
+
+    @Bean
+    public AlertNotificationCommandHandler alertNotificationCommandHandler() {
+        return new AlertNotificationCommandHandler();
+    }
+
+    @Bean
+    public ResolvePropertyCommandHandler resolvePropertyCommandHandler() {
+        return new ResolvePropertyCommandHandler();
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/ConnectorConfiguration.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/ConnectorConfiguration.java
@@ -1,0 +1,460 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.configuration;
+
+import io.gravitee.ae.connector.ws.Endpoint;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.AbstractEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MapPropertySource;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ConnectorConfiguration {
+
+    private static final String DEFAULT_ENDPOINT = "http://localhost:8072";
+    private static final String DEFAULT_ENGINE_NAME = "default";
+
+    @Autowired
+    private Environment environment;
+
+    /**
+     * Alert Engine basic auth login.
+     */
+    @Value("${alerts.alert-engine.ws.security.username:#{null}}")
+    private String username;
+
+    /**
+     * Alert Engine basic auth password.
+     */
+    @Value("${alerts.alert-engine.ws.security.password:#{null}}")
+    private String password;
+
+    /**
+     * Alert Engine ssl keystore type. (jks, pkcs12,)
+     */
+    @Value("${alerts.alert-engine.ws.ssl.keystore.type:#{null}}")
+    private String keystoreType;
+
+    /**
+     * Alert Engine ssl keystore path.
+     */
+    @Value("${alerts.alert-engine.ws.ssl.keystore.path:#{null}}")
+    private String keystorePath;
+
+    /**
+     * Alert Engine ssl keystore password.
+     */
+    @Value("${alerts.alert-engine.ws.ssl.keystore.password:#{null}}")
+    private String keystorePassword;
+
+    /**
+     * Alert Engine ssl pem certs paths
+     */
+    private List<String> keystorePemCerts;
+
+    /**
+     * Alert Engine ssl pem keys paths
+     */
+    private List<String> keystorePemKeys;
+
+    /**
+     * Alert Engine ssl truststore trustall.
+     */
+    @Value("${alerts.alert-engine.ws.ssl.trustall:false}")
+    private boolean trustAll;
+
+    /**
+     * Alert Engine ssl truststore hostname verifier.
+     */
+    @Value("${alerts.alert-engine.ws.ssl.verifyHostname:true}")
+    private boolean hostnameVerifier;
+
+    /**
+     * Alert Engine ssl truststore type.
+     */
+    @Value("${alerts.alert-engine.ws.ssl.truststore.type:#{null}}")
+    private String truststoreType;
+
+    /**
+     * Alert Engine ssl truststore path.
+     */
+    @Value("${alerts.alert-engine.ws.ssl.truststore.path:#{null}}")
+    private String truststorePath;
+
+    /**
+     * Alert Engine ssl truststore password.
+     */
+    @Value("${alerts.alert-engine.ws.ssl.truststore.password:#{null}}")
+    private String truststorePassword;
+
+    /**
+     * Connection timeout. Default to 5000.
+     */
+    @Value("${alerts.alert-engine.ws.connectTimeout:5000}")
+    private int connectTimeout;
+
+    /**
+     * Request timeout (useful when relying on http to send events). Default is 2000ms.
+     */
+    @Value("${alerts.alert-engine.ws.requestTimeout:2000}")
+    private int requestTimeout;
+
+    /**
+     * Idle timeout. After this duration, the connection will be released.
+     * Default is 120000 ms (2 minutes).
+     */
+    @Value("${alerts.alert-engine.ws.idleTimeout:120000}")
+    private int idleTimeout;
+
+    /**
+     * Indicates if connection keep alive is enabled or not.
+     * Default is true.
+     */
+    @Value("${alerts.alert-engine.ws.keepAlive:true}")
+    private boolean keepAlive;
+
+    /**
+     * Indicates if pipelining is enabled or not. When pipelining is enabled, mulitple event packets will be sent in a single connection without waiting for the previous responses.
+     * Enabling pipeline can increase performances.
+     * Default is true.
+     */
+    @Value("${alerts.alert-engine.ws.pipelining:true}")
+    private boolean pipelining;
+
+    /**
+     * Indicates if compression is enabled when sending events. The compression must also be enabled on alert engine ingester.
+     * Default is true.
+     */
+    @Value("${alerts.alert-engine.ws.tryCompression:true}")
+    private boolean tryCompression;
+
+    /**
+     * Set the maximum number of connections (useful when relying on http to send events). Default is 50.
+     */
+    @Value("${alerts.alert-engine.ws.maxPoolSize:50}")
+    private int maxPoolSize;
+
+    /**
+     * Set bulk events size. Default is 100.
+     */
+    @Value("${alerts.alert-engine.ws.bulkEventsSize:100}")
+    private int bulkEventsSize;
+
+    /**
+     * Set the duration to wait for bulk events to be ready for sending.
+     * Ex: a value of 100ms means that if after 100ms the number of events to send is below to <code>bulkEventSize</code>, then the events will be sent.
+     * If the number of events is larger than <code>bulkEventSize</code>, then a bulk of <code>bulkEventSize</code> events will be sent immediately.
+     * Default is 100ms.
+     */
+    @Value("${alerts.alert-engine.ws.bulkEventsWait:100}")
+    private int bulkEventsWait;
+
+    /**
+     * Indicates if events should be sent over http or not.
+     * By default, to keep the same behavior of the previous version, events are sent over a websocket connection.
+     * The default behavior will switch to http in a next future version.
+     */
+    @Value("${alerts.alert-engine.ws.sendEventsOnHttp:false}")
+    private boolean sendEventsOnHttp;
+
+    private Map<String, Engine> engines;
+
+    public Engine getDefaultEngine() {
+        return getEngines().get(DEFAULT_ENGINE_NAME);
+    }
+
+    private List<String> initializeEndpoints(String key) {
+        String fullKey = String.format("%s[%s]", key, 0);
+        List<String> result = new ArrayList<>();
+
+        while (environment.containsProperty(fullKey)) {
+            String url = environment.getProperty(fullKey);
+            result.add(url);
+
+            fullKey = String.format("%s[%s]", key, result.size());
+        }
+
+        // Use default host if required
+        if (result.isEmpty()) {
+            result.add(DEFAULT_ENDPOINT);
+        }
+
+        return result;
+    }
+
+    private Map<String, Engine> initializeEngines() {
+        String keyInitial = "alerts.alert-engine.engines.";
+        Map<String, Engine> result = new HashMap<>();
+
+        // try first with engines tag
+        final var engineNames = new HashSet<String>();
+        ((AbstractEnvironment) environment).getPropertySources()
+            .stream()
+            .collect(Collectors.toList())
+            .forEach(propertySource -> {
+                if (propertySource instanceof MapPropertySource) {
+                    ((MapPropertySource) propertySource).getSource()
+                        .forEach((k, v) -> {
+                            if (k.startsWith(keyInitial)) {
+                                String replace = k.replace(keyInitial, "");
+                                String name = replace.substring(0, replace.indexOf("."));
+                                engineNames.add(name);
+                            }
+                        });
+                }
+            });
+
+        engineNames.forEach(name -> {
+            String key = String.format("%s%s", keyInitial, name);
+            List<Endpoint> endpointList = initializeEndpoints(key + ".endpoints").stream().map(Endpoint::new).collect(Collectors.toList());
+            String uname = environment.getProperty(key + ".security.username");
+            String pass = environment.getProperty(key + ".security.password");
+
+            result.put(name, new Engine(this, endpointList, new Engine.Security(uname, pass)));
+        });
+
+        if (!result.isEmpty()) {
+            if (result.get(DEFAULT_ENGINE_NAME) == null) {
+                throw new RuntimeException("Default engine is not found! You need to have a default engine in your configuration.");
+            }
+        } else { // for backward compatibility
+            Engine defaultEngine = new Engine(
+                this,
+                initializeEndpoints("alerts.alert-engine.ws.endpoints").stream().map(Endpoint::new).collect(Collectors.toList()),
+                new Engine.Security(this.getUsername(), this.getPassword())
+            );
+
+            result.put(DEFAULT_ENGINE_NAME, defaultEngine);
+        }
+
+        return result;
+    }
+
+    // Property methods
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getKeystoreType() {
+        return keystoreType;
+    }
+
+    public void setKeystoreType(String keystoreType) {
+        this.keystoreType = keystoreType;
+    }
+
+    public String getKeystorePath() {
+        return keystorePath;
+    }
+
+    public void setKeystorePath(String keystorePath) {
+        this.keystorePath = keystorePath;
+    }
+
+    public String getKeystorePassword() {
+        return keystorePassword;
+    }
+
+    public void setKeystorePassword(String keystorePassword) {
+        this.keystorePassword = keystorePassword;
+    }
+
+    public List<String> getKeystorePemCerts() {
+        if (keystorePemCerts == null) {
+            keystorePemCerts = initializeKeystorePemCerts("alerts.alert-engine.ws.ssl.keystore.certs[%s]");
+        }
+
+        return keystorePemCerts;
+    }
+
+    private List<String> initializeKeystorePemCerts(String property) {
+        String key = String.format(property, 0);
+        List<String> values = new ArrayList<>();
+
+        while (environment.containsProperty(key)) {
+            values.add(environment.getProperty(key));
+            key = String.format(property, values.size());
+        }
+
+        return values;
+    }
+
+    public void setKeystorePemCerts(List<String> keystorePemCerts) {
+        this.keystorePemCerts = keystorePemCerts;
+    }
+
+    public List<String> getKeystorePemKeys() {
+        if (keystorePemKeys == null) {
+            keystorePemKeys = initializeKeystorePemCerts("alerts.alert-engine.ws.ssl.keystore.keys[%s]");
+        }
+
+        return keystorePemKeys;
+    }
+
+    public void setKeystorePemKeys(List<String> keystorePemKeys) {
+        this.keystorePemKeys = keystorePemKeys;
+    }
+
+    public boolean isTrustAll() {
+        return trustAll;
+    }
+
+    public void setTrustAll(boolean trustAll) {
+        this.trustAll = trustAll;
+    }
+
+    public boolean isHostnameVerifier() {
+        return hostnameVerifier;
+    }
+
+    public void setHostnameVerifier(boolean hostnameVerifier) {
+        this.hostnameVerifier = hostnameVerifier;
+    }
+
+    public String getTruststoreType() {
+        return truststoreType;
+    }
+
+    public void setTruststoreType(String truststoreType) {
+        this.truststoreType = truststoreType;
+    }
+
+    public String getTruststorePath() {
+        return truststorePath;
+    }
+
+    public void setTruststorePath(String truststorePath) {
+        this.truststorePath = truststorePath;
+    }
+
+    public String getTruststorePassword() {
+        return truststorePassword;
+    }
+
+    public void setTruststorePassword(String truststorePassword) {
+        this.truststorePassword = truststorePassword;
+    }
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public int getMaxPoolSize() {
+        return maxPoolSize;
+    }
+
+    public void setMaxPoolSize(int maxPoolSize) {
+        this.maxPoolSize = maxPoolSize;
+    }
+
+    public int getRequestTimeout() {
+        return requestTimeout;
+    }
+
+    public void setRequestTimeout(int requestTimeout) {
+        this.requestTimeout = requestTimeout;
+    }
+
+    public int getBulkEventsSize() {
+        return bulkEventsSize;
+    }
+
+    public void setBulkEventsSize(int bulkEventsSize) {
+        this.bulkEventsSize = bulkEventsSize;
+    }
+
+    public int getBulkEventsWait() {
+        return bulkEventsWait;
+    }
+
+    public void setBulkEventsWait(int bulkEventsWait) {
+        this.bulkEventsWait = bulkEventsWait;
+    }
+
+    public int getIdleTimeout() {
+        return idleTimeout;
+    }
+
+    public void setIdleTimeout(int idleTimeout) {
+        this.idleTimeout = idleTimeout;
+    }
+
+    public boolean isSendEventsOnHttp() {
+        return sendEventsOnHttp;
+    }
+
+    public void setSendEventsOnHttp(boolean sendEventsOnHttp) {
+        this.sendEventsOnHttp = sendEventsOnHttp;
+    }
+
+    public boolean isKeepAlive() {
+        return keepAlive;
+    }
+
+    public void setKeepAlive(boolean keepAlive) {
+        this.keepAlive = keepAlive;
+    }
+
+    public boolean isPipelining() {
+        return pipelining;
+    }
+
+    public void setPipelining(boolean pipelining) {
+        this.pipelining = pipelining;
+    }
+
+    public boolean isTryCompression() {
+        return tryCompression;
+    }
+
+    public void setTryCompression(boolean tryCompression) {
+        this.tryCompression = tryCompression;
+    }
+
+    public Map<String, Engine> getEngines() {
+        if (engines == null) {
+            engines = initializeEngines();
+        }
+
+        return engines;
+    }
+
+    public void setEngines(Map<String, Engine> engines) {
+        this.engines = engines;
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/Engine.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/Engine.java
@@ -1,0 +1,239 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.configuration;
+
+import io.gravitee.ae.connector.ws.Endpoint;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.core.net.PfxOptions;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class Engine {
+
+    private static final Logger logger = LoggerFactory.getLogger(Engine.class);
+    private static final String KEYSTORE_FORMAT_JKS = "JKS";
+    private static final String KEYSTORE_FORMAT_PEM = "PEM";
+    private static final String KEYSTORE_FORMAT_PKCS12 = "PKCS12";
+    private static final String HTTPS_SCHEME = "https";
+    private static final int DEFAULT_HTTP_PORT = 80;
+    private static final int DEFAULT_HTTPS_PORT = 443;
+    protected final AtomicInteger counter = new AtomicInteger(0);
+    private final Map<Endpoint, AtomicInteger> endpointsRetryCount = new HashMap<>();
+    private Endpoint currentEndpoint;
+
+    private ConnectorConfiguration connectorConfiguration;
+    private List<Endpoint> endpoints;
+    private Security security;
+
+    public Engine() {}
+
+    public Engine(ConnectorConfiguration connectorConfiguration, List<Endpoint> endpoints, Security security) {
+        this.connectorConfiguration = connectorConfiguration;
+        this.endpoints = endpoints;
+        this.security = security;
+    }
+
+    public HttpClientOptions getHttpClientOptions(Endpoint endpoint) {
+        URI target = URI.create(endpoint.getUrl());
+        final int port = target.getPort() != -1
+            ? target.getPort()
+            : (HTTPS_SCHEME.equals(target.getScheme()) ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT);
+        HttpClientOptions httpClientOptions = new HttpClientOptions();
+        httpClientOptions.setConnectTimeout(connectorConfiguration.getConnectTimeout());
+        httpClientOptions.setDefaultPort(port);
+        httpClientOptions.setDefaultHost(target.getHost());
+        httpClientOptions.setMaxPoolSize(connectorConfiguration.getMaxPoolSize());
+        httpClientOptions.setIdleTimeout(connectorConfiguration.getIdleTimeout());
+        httpClientOptions.setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+        httpClientOptions.setPipelining(connectorConfiguration.isPipelining());
+        httpClientOptions.setKeepAlive(connectorConfiguration.isKeepAlive());
+        httpClientOptions.setTryUseCompression(connectorConfiguration.isTryCompression());
+
+        if (HTTPS_SCHEME.equalsIgnoreCase(target.getScheme())) {
+            // Configure SSL
+            httpClientOptions.setSsl(true);
+            httpClientOptions.setTrustAll(connectorConfiguration.isTrustAll());
+            httpClientOptions.setVerifyHost(connectorConfiguration.isHostnameVerifier());
+
+            if (connectorConfiguration.getKeystoreType() != null) {
+                if (connectorConfiguration.getKeystoreType().equalsIgnoreCase(KEYSTORE_FORMAT_JKS)) {
+                    httpClientOptions.setKeyStoreOptions(
+                        new JksOptions()
+                            .setPath(connectorConfiguration.getKeystorePath())
+                            .setPassword(connectorConfiguration.getKeystorePassword())
+                    );
+                } else if (connectorConfiguration.getKeystoreType().equalsIgnoreCase(KEYSTORE_FORMAT_PKCS12)) {
+                    httpClientOptions.setPfxKeyCertOptions(
+                        new PfxOptions()
+                            .setPath(connectorConfiguration.getKeystorePath())
+                            .setPassword(connectorConfiguration.getKeystorePassword())
+                    );
+                } else if (connectorConfiguration.getKeystoreType().equalsIgnoreCase(KEYSTORE_FORMAT_PEM)) {
+                    httpClientOptions.setPemKeyCertOptions(
+                        new PemKeyCertOptions()
+                            .setCertPaths(connectorConfiguration.getKeystorePemCerts())
+                            .setKeyPaths(connectorConfiguration.getKeystorePemKeys())
+                    );
+                }
+            }
+
+            if (connectorConfiguration.getTruststoreType() != null) {
+                if (connectorConfiguration.getTruststoreType().equalsIgnoreCase(KEYSTORE_FORMAT_JKS)) {
+                    httpClientOptions.setTrustStoreOptions(
+                        new JksOptions()
+                            .setPath(connectorConfiguration.getTruststorePath())
+                            .setPassword(connectorConfiguration.getTruststorePassword())
+                    );
+                } else if (connectorConfiguration.getTruststoreType().equalsIgnoreCase(KEYSTORE_FORMAT_PKCS12)) {
+                    httpClientOptions.setPfxTrustOptions(
+                        new PfxOptions()
+                            .setPath(connectorConfiguration.getTruststorePath())
+                            .setPassword(connectorConfiguration.getTruststorePassword())
+                    );
+                } else if (connectorConfiguration.getTruststoreType().equalsIgnoreCase(KEYSTORE_FORMAT_PEM)) {
+                    httpClientOptions.setPemTrustOptions(new PemTrustOptions().addCertPath(connectorConfiguration.getTruststorePath()));
+                }
+            }
+        }
+
+        return httpClientOptions;
+    }
+
+    public Endpoint nextEndpoint() {
+        int size = endpoints.size();
+        if (size == 0) {
+            currentEndpoint = null;
+            return null;
+        }
+
+        Endpoint endpoint = endpoints.get(Math.abs(counter.getAndIncrement() % size));
+        endpointsRetryCount.computeIfAbsent(endpoint, k -> new AtomicInteger(0));
+
+        int tryConnect = endpointsRetryCount.get(endpoint).incrementAndGet();
+        if (tryConnect > 5 && endpoint.isRemovable()) {
+            logger.info("Alert engine connector tries to connect to instance at {} 5 times. Removing instance...", endpoint.getUrl());
+            endpoints.remove(endpoint);
+            return nextEndpoint();
+        }
+
+        currentEndpoint = endpoint;
+        return endpoint;
+    }
+
+    public Endpoint currentEndpoint() {
+        return currentEndpoint;
+    }
+
+    public void resetEndpointRetryCount(Endpoint endpoint) {
+        endpointsRetryCount.get(endpoint).set(0);
+    }
+
+    public Integer getEndpointRetryCount(Endpoint endpoint) {
+        return endpointsRetryCount.get(endpoint).get();
+    }
+
+    // Property methods
+    public ConnectorConfiguration getConnectorConfiguration() {
+        return connectorConfiguration;
+    }
+
+    public void setConnectorConfiguration(ConnectorConfiguration connectorConfiguration) {
+        this.connectorConfiguration = connectorConfiguration;
+    }
+
+    public List<Endpoint> getEndpoints() {
+        return endpoints;
+    }
+
+    public void setEndpoints(List<Endpoint> endpoints) {
+        this.endpoints = endpoints;
+    }
+
+    public Security getSecurity() {
+        return security;
+    }
+
+    public void setSecurity(Security value) {
+        this.security = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Engine engine = (Engine) o;
+        return Objects.equals(endpoints, engine.endpoints) && Objects.equals(security, engine.security);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(endpoints, security);
+    }
+
+    public static class Security {
+
+        private String username;
+        private String password;
+
+        public Security(String username, String password) {
+            this.username = username;
+            this.password = password;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String value) {
+            this.username = value;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String value) {
+            this.password = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Security security = (Security) o;
+            return Objects.equals(username, security.username) && Objects.equals(password, security.password);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(username, password);
+        }
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/listener/ListenerManager.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/listener/ListenerManager.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.listener;
+
+import io.gravitee.alert.api.Listener;
+import java.util.List;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface ListenerManager {
+    void addListener(Listener listener);
+
+    <T extends Listener> List<T> getListeners(Class<T> listenerClass);
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/listener/ListenerManagerImpl.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/listener/ListenerManagerImpl.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.listener;
+
+import io.gravitee.alert.api.Listener;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ListenerManagerImpl implements ListenerManager {
+
+    private final CopyOnWriteArrayList<Listener> listeners = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void addListener(Listener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public <T extends Listener> List<T> getListeners(Class<T> listenerClass) {
+        return listeners
+            .stream()
+            .filter(listener -> listenerClass.isAssignableFrom(listener.getClass()))
+            .map(listener -> (T) listener)
+            .collect(Collectors.toList());
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/spring/WsConnectorConfiguration.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/spring/WsConnectorConfiguration.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.spring;
+
+import io.gravitee.ae.connector.core.spring.CoreConnectorConfiguration;
+import io.gravitee.ae.connector.ws.WsEventProducer;
+import io.gravitee.ae.connector.ws.WsTriggerProvider;
+import io.gravitee.ae.connector.ws.command.spring.CommandConfiguration;
+import io.gravitee.ae.connector.ws.configuration.ConnectorConfiguration;
+import io.gravitee.ae.connector.ws.listener.ListenerManager;
+import io.gravitee.ae.connector.ws.listener.ListenerManagerImpl;
+import io.gravitee.alert.api.event.EventProducer;
+import io.gravitee.alert.api.trigger.TriggerProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Configuration
+@Import({ CommandConfiguration.class, CoreConnectorConfiguration.class })
+public class WsConnectorConfiguration {
+
+    @Bean
+    public ConnectorConfiguration websocketConnectorConfiguration() {
+        return new ConnectorConfiguration();
+    }
+
+    @Bean
+    public EventProducer eventProducer() {
+        return new WsEventProducer();
+    }
+
+    @Bean
+    public TriggerProvider triggerProvider() {
+        return new WsTriggerProvider();
+    }
+
+    @Bean
+    public ListenerManager listenerManager() {
+        return new ListenerManagerImpl();
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/resources/plugin.properties
+++ b/gravitee-alert-engine-connector-ws/src/main/resources/plugin.properties
@@ -1,0 +1,6 @@
+id=alert-engine-connector-ws
+name=${project.name}
+version=${project.version}
+description=${project.description}
+class=io.gravitee.ae.connector.ws.WsConnectorPlugin
+type=alert

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee</groupId>
+        <artifactId>gravitee-parent</artifactId>
+        <version>20.2</version>
+    </parent>
+
+    <groupId>io.gravitee.ae</groupId>
+    <artifactId>gravitee-alert-engine-connectors</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Gravitee.io - Alert Engine - Connectors</name>
+
+    <modules>
+        <module>gravitee-alert-engine-connector-api</module>
+        <module>gravitee-alert-engine-connector-core</module>
+        <module>gravitee-alert-engine-connector-ws</module>
+    </modules>
+
+    <properties>
+        <gravitee-bom.version>2.5</gravitee-bom.version>
+        <gravitee-node.version>1.24.0</gravitee-node.version>
+        <gravitee-plugin.version>1.23.1</gravitee-plugin.version>
+        <gravitee-alert-api.version>1.9.0</gravitee-alert-api.version>
+        <mockito.version>4.5.1</mockito.version>
+        <assertj.version>3.22.0</assertj.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <!-- Gravitee.io -->
+            <dependency>
+                <groupId>io.gravitee.cockpit</groupId>
+                <artifactId>gravitee-cockpit-api</artifactId>
+                <version>${gravitee-cockpit-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.alert</groupId>
+                <artifactId>gravitee-alert-api</artifactId>
+                <version>${gravitee-alert-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.plugin</groupId>
+                <artifactId>gravitee-plugin</artifactId>
+                <version>${gravitee-plugin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node</artifactId>
+                <version>${gravitee-node.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Test dependencies -->
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.gravitee.alert</groupId>
+            <artifactId>gravitee-alert-api</artifactId>
+            <version>${gravitee-alert-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <!-- Reactive dependencies -->
+        <dependency>
+            <groupId>io.reactivex.rxjava2</groupId>
+            <artifactId>rxjava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.4.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M6</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.hubspot.maven.plugins</groupId>
+                <artifactId>prettier-maven-plugin</artifactId>
+                <version>0.17</version>
+                <configuration>
+                    <nodeVersion>12.13.0</nodeVersion>
+                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
closes gravitee-io/issues#7778
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-issues-7778-extract-ae-connector-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/ae/gravitee-alert-engine-connectors/1.0.0-issues-7778-extract-ae-connector-SNAPSHOT/gravitee-alert-engine-connectors-1.0.0-issues-7778-extract-ae-connector-SNAPSHOT.zip)
  <!-- Version placeholder end -->
