### PR TITLE
feat: send events on http as default behaviour

### DIFF
--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/ConnectorConfiguration.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/ConnectorConfiguration.java
@@ -170,10 +170,10 @@ public class ConnectorConfiguration {
 
     /**
      * Indicates if events should be sent over http or not.
-     * By default, to keep the same behavior of the previous version, events are sent over a websocket connection.
-     * The default behavior will switch to http in a next future version.
+     * If `false`, events will be sent over websocket, http otherwise
+     * Default is `true`
      */
-    @Value("${alerts.alert-engine.ws.sendEventsOnHttp:false}")
+    @Value("${alerts.alert-engine.ws.sendEventsOnHttp:true}")
     private boolean sendEventsOnHttp;
 
     private Map<String, Engine> engines;


### PR DESCRIPTION
**Description**

This issue turns the behaviour of sending events to http 

**Additional context**

Tested with APIM latest master
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-AE-15-event-connector-http-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/ae/gravitee-alert-engine-connectors/2.0.0-AE-15-event-connector-http-SNAPSHOT/gravitee-alert-engine-connectors-2.0.0-AE-15-event-connector-http-SNAPSHOT.zip)
  <!-- Version placeholder end -->
