### PR TITLE
chore(deps): upgrade to gravitee.node 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <gravitee-bom.version>2.8</gravitee-bom.version>
-        <gravitee-node.version>2.0.0-alpha.3</gravitee-node.version>
+        <gravitee-node.version>2.0.0</gravitee-node.version>
         <gravitee-plugin.version>1.24.1</gravitee-plugin.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <mockito.version>4.5.1</mockito.version>


### PR DESCRIPTION
**Description**

This PR upgrades the gravitee node version to 2.0.0
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-chore-gravitee-node-2-0-0-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/ae/gravitee-alert-engine-connectors/2.0.0-chore-gravitee-node-2-0-0-SNAPSHOT/gravitee-alert-engine-connectors-2.0.0-chore-gravitee-node-2-0-0-SNAPSHOT.zip)
  <!-- Version placeholder end -->
