### PR TITLE
chore(deps): bump gravitee bom and gravitee parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.5</version>
+        <version>21.0.0</version>
     </parent>
 
     <groupId>io.gravitee.ae</groupId>
@@ -40,7 +40,7 @@
     </modules>
 
     <properties>
-        <gravitee-bom.version>2.8</gravitee-bom.version>
+        <gravitee-bom.version>3.0.0</gravitee-bom.version>
         <gravitee-node.version>2.0.0</gravitee-node.version>
         <gravitee-plugin.version>1.24.1</gravitee-plugin.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>


### PR DESCRIPTION
**Description**

This PR bumps bom and parent dependencies to the latest
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-chore-bom-parent-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/ae/gravitee-alert-engine-connectors/2.0.0-chore-bom-parent-dependencies-SNAPSHOT/gravitee-alert-engine-connectors-2.0.0-chore-bom-parent-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
