### PR TITLE
feat: allow different engines to connect with independant ssl configu…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,12 @@ admin/console/dist
 .settings/
 .classpath
 .project
+
+# .env files (docker compose, etc.)
+**/.env
+
+# also keystore and certificate files
+**/keystores/
+*.jks
+*.pem
+

--- a/docker/integration-tests/one-apim_two-ae/.env.template
+++ b/docker/integration-tests/one-apim_two-ae/.env.template
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# PATH to the gravitee licence.key file
+LICENCE_KEY_PATH=/path/to/the/Gravitee/Licenses/license.key
+AE_VERSION=latest

--- a/docker/integration-tests/one-apim_two-ae/alert-engine_gravitee_1.yml
+++ b/docker/integration-tests/one-apim_two-ae/alert-engine_gravitee_1.yml
@@ -1,0 +1,88 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+############################################################################################################
+################################## Gravitee.io Alert Engine - Configuration ################################
+############################################################################################################
+
+############################################################################################################
+# This file is the general configuration of Gravitee.io Alert Engine:
+# - Properties (and respective default values) in comment are provided for information.
+# - You can reference other property by using ${property.name} syntax
+# - gravitee.home property is automatically set-up by launcher and refers to the installation path. Do not override it !
+#
+############################################################################################################
+
+# Ingesters
+ingesters:
+  ws:
+    instances: 0
+    port: 8072
+    host: alert-engine-1
+    secured: true
+    alpn: false
+    ssl:
+      clientAuth: false
+      keystore:
+        type: jks # Supports jks, pem, pkcs12
+        path: /secure/keystore.jks
+        password: unsecure
+      truststore:
+        type: jks # Supports jks, pem, pkcs12
+        path: /secure/keystore.jks
+        password: unsecure
+    authentication: # authentication type to be used for HTTP authentication
+      type: basic # none to disable authentication / basic for basic authentication
+      users:
+        admin: adminadmin
+
+# Alert service configurations. Provided values are default values.
+# All services are enabled by default. To stop one of them, you have to add the property 'enabled: false'.
+services:
+  core:
+    http:
+      enabled: true
+      port: 18072
+      host: localhost
+      authentication:
+        # authentication type to be used for the core services
+        # - none : to disable authentication
+        # - basic : to use basic authentication
+        # default is "basic"
+        type: basic
+        users:
+          admin: adminadmin
+  metrics:
+    enabled: false
+    prometheus:
+      enabled: true
+
+cluster:
+  sync:
+    time:
+      value: 30
+      unit: SECONDS
+
+  hazelcast:
+    # Hazelcast system properties (see https://docs.hazelcast.org/docs/latest/manual/html-single/#system-properties)
+    # Use the same properties without 'hazelcast.' prefix.
+    #systemProperties:
+      # Timeout to wait for a response when a remote call is sent, in milliseconds.
+      #operation.call.timeout.millis: 60000
+      # Socket connection timeout in seconds. Socket.connect() is blocked until either connection is established or connection is refused or this timeout passes. Default is 0, means infinite.
+      #socket.connect.timeout.seconds: 0
+    config:
+      path: ${gravitee.home}/config/hazelcast.xml

--- a/docker/integration-tests/one-apim_two-ae/alert-engine_gravitee_2.yml
+++ b/docker/integration-tests/one-apim_two-ae/alert-engine_gravitee_2.yml
@@ -1,0 +1,88 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+############################################################################################################
+################################## Gravitee.io Alert Engine - Configuration ################################
+############################################################################################################
+
+############################################################################################################
+# This file is the general configuration of Gravitee.io Alert Engine:
+# - Properties (and respective default values) in comment are provided for information.
+# - You can reference other property by using ${property.name} syntax
+# - gravitee.home property is automatically set-up by launcher and refers to the installation path. Do not override it !
+#
+############################################################################################################
+
+# Ingesters
+ingesters:
+  ws:
+    instances: 0
+    port: 8072
+    host: alert-engine-2
+    secured: true
+    alpn: false
+    ssl:
+      clientAuth: false
+      keystore:
+        type: jks # Supports jks, pem, pkcs12
+        path: /secure/keystore.jks
+        password: unsecure
+      truststore:
+        type: jks # Supports jks, pem, pkcs12
+        path: /secure/keystore.jks
+        password: unsecure
+    authentication: # authentication type to be used for HTTP authentication
+      type: basic # none to disable authentication / basic for basic authentication
+      users:
+        admin: adminadmin
+
+# Alert service configurations. Provided values are default values.
+# All services are enabled by default. To stop one of them, you have to add the property 'enabled: false'.
+services:
+  core:
+    http:
+      enabled: true
+      port: 18072
+      host: localhost
+      authentication:
+        # authentication type to be used for the core services
+        # - none : to disable authentication
+        # - basic : to use basic authentication
+        # default is "basic"
+        type: basic
+        users:
+          admin: adminadmin
+  metrics:
+    enabled: false
+    prometheus:
+      enabled: true
+
+cluster:
+  sync:
+    time:
+      value: 30
+      unit: SECONDS
+
+  hazelcast:
+    # Hazelcast system properties (see https://docs.hazelcast.org/docs/latest/manual/html-single/#system-properties)
+    # Use the same properties without 'hazelcast.' prefix.
+    #systemProperties:
+      # Timeout to wait for a response when a remote call is sent, in milliseconds.
+      #operation.call.timeout.millis: 60000
+      # Socket connection timeout in seconds. Socket.connect() is blocked until either connection is established or connection is refused or this timeout passes. Default is 0, means infinite.
+      #socket.connect.timeout.seconds: 0
+    config:
+      path: ${gravitee.home}/config/hazelcast.xml

--- a/docker/integration-tests/one-apim_two-ae/docker-compose.yml
+++ b/docker/integration-tests/one-apim_two-ae/docker-compose.yml
@@ -1,0 +1,226 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: '3.9'
+
+networks:
+  control-plan:
+  ae-1:
+  ae-2:
+
+volumes:
+  data-elasticsearch:
+  data-mongo:
+
+x-pluginAEconnector: &pluginAEconnector
+  type: bind
+  source: ./../../../gravitee-alert-engine-connector-ws/target/gravitee-ae-connectors-ws-2.0.0.zip
+  target: /opt/graviteeio-gateway/plugins/gravitee-alert-engine-connectors-ws-2.0.0.zip
+  read_only: true
+
+services:
+
+  mongodb:
+    image: mongo:${MONGODB_VERSION:-5}
+    healthcheck:
+      test: [ "CMD", "mongo", "--quiet", "localhost/test", "--eval", "quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)" ]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+    volumes:
+      - data-mongo:/data/db
+    networks:
+      - control-plan
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    healthcheck:
+      test: [ "CMD", "curl", "-fsSL", "http://localhost:9200/_cat/health?h=status" ]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+    volumes:
+      - data-elasticsearch:/usr/share/elasticsearch/data
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=0.0.0.0
+      - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+      - cluster.name=elasticsearch
+      - bootstrap.memory_lock=true
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile: 65536
+    networks:
+      - control-plan
+
+  gateway-1:
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
+    healthcheck:
+      test: [ "CMD", "curl", "--user", "admin:adminadmin", "--fail", "http://localhost:18082/_node/health" ]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    depends_on:
+      - mongodb
+      - elasticsearch
+      - alert-engine-1
+      - alert-engine-2
+    volumes:
+      - ${LICENCE_KEY_PATH}:/opt/graviteeio-gateway/license/license.key:ro
+      - ./keystores/keystore-gateway-1.jks:/secure/keystore.jks:ro
+      - ./gateway_gravitee_1.yml:/opt/graviteeio-gateway/config/gravitee.yml:ro
+      - *pluginAEconnector
+    environment:
+      - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - gravitee_ratelimit_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
+      - gravitee_plugins_path_0=$${gravitee.home}/plugins
+    networks:
+      - control-plan
+      - ae-1
+
+  gateway-2:
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
+    healthcheck:
+      test: [ "CMD", "curl", "--user", "admin:adminadmin", "--fail", "http://localhost:18082/_node/health" ]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    depends_on:
+      - mongodb
+      - elasticsearch
+      - alert-engine-1
+      - alert-engine-2
+    volumes:
+      - ${LICENCE_KEY_PATH}:/opt/graviteeio-gateway/license/license.key:ro
+      - ./keystores/keystore-gateway-2.jks:/secure/keystore.jks:ro
+      - ./gateway_gravitee_2.yml:/opt/graviteeio-gateway/config/gravitee.yml:ro
+      - *pluginAEconnector
+    environment:
+      - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - gravitee_ratelimit_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
+      - gravitee_plugins_path_0=$${gravitee.home}/plugins
+    networks:
+      - control-plan
+      - ae-2
+
+  management-api:
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
+    healthcheck:
+      test: [ "CMD", "curl", "--user", "admin:adminadmin", "--fail", "http://localhost:18083/_node/health" ]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    ports:
+      - "8081:8083"
+    links:
+      - mongodb
+      - elasticsearch
+      - alert-engine-1
+      - alert-engine-2
+      - gateway-1
+      - gateway-2
+    depends_on:
+      - mongodb
+      - elasticsearch
+    volumes:
+      - ${LICENCE_KEY_PATH}:/opt/graviteeio-management-api/license/license.key:ro
+      - ./keystores/keystore-management-api.jks:/secure/keystore.jks:ro
+      - ./management-api_gravitee.yml:/opt/graviteeio-management-api/config/gravitee.yml:ro
+      - <<: *pluginAEconnector
+        target: /opt/graviteeio-management-api/plugins/gravitee-alert-engine-connectors-ws-2.0.0.zip
+    environment:
+      - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - gravitee_analytics_elasticsearch_endpoints_0=http://elasticsearch:9200
+      - gravitee_plugins_path_0=$${gravitee.home}/plugins
+    networks:
+      - control-plan
+      - ae-1
+      - ae-2
+
+  management-ui:
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
+    ports:
+      - "8080:8080"
+    depends_on:
+      - management-api
+    environment:
+      - MGMT_API_URL=http://localhost:8081/management/organizations/DEFAULT/environments/DEFAULT/
+    networks:
+      - control-plan
+
+  alert-engine-1:
+    image: graviteeio/ae-engine:${AE_VERSION:-latest}
+    stop_grace_period: 5m
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://admin:adminadmin@localhost:18072/_node" ]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 768M
+        reservations:
+          cpus: '1'
+          memory: 512M
+    environment:
+      - JAVA_OPTS=-Dlogging.level.com.graviteesource.ae.cluster.hz.channel.HazelcastChannelManager=DEBUG -Dlogging.level.com.graviteesource.ae.core.listener.EventListenerVerticle=DEBUG
+      - GIO_MIN_MEM=128m
+      - GIO_MAX_MEM=512m
+    volumes:
+      - ${LICENCE_KEY_PATH}:/opt/graviteeio-alert-engine/license/license.key:ro
+      - ./keystores/keystore-alert-engine-1.jks:/secure/keystore.jks:ro
+      - ./alert-engine_gravitee_1.yml:/opt/graviteeio-alert-engine/config/gravitee.yml:ro
+    networks:
+      - ae-1
+
+  alert-engine-2:
+    image: graviteeio/ae-engine:${AE_VERSION:-latest}
+    stop_grace_period: 5m
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://admin:adminadmin@localhost:18072/_node" ]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 768M
+        reservations:
+          cpus: '1'
+          memory: 512M
+    environment:
+      - JAVA_OPTS=-Dlogging.level.com.graviteesource.ae.cluster.hz.channel.HazelcastChannelManager=DEBUG -Dlogging.level.com.graviteesource.ae.core.listener.EventListenerVerticle=DEBUG
+      - GIO_MIN_MEM=128m
+      - GIO_MAX_MEM=512m
+    volumes:
+      - ${LICENCE_KEY_PATH}:/opt/graviteeio-alert-engine/license/license.key:ro
+      - ./keystores/keystore-alert-engine-2.jks:/secure/keystore.jks:ro
+      - ./alert-engine_gravitee_2.yml:/opt/graviteeio-alert-engine/config/gravitee.yml:ro
+    networks:
+      - ae-2

--- a/docker/integration-tests/one-apim_two-ae/gateway_gravitee_1.yml
+++ b/docker/integration-tests/one-apim_two-ae/gateway_gravitee_1.yml
@@ -1,0 +1,484 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+############################################################################################################
+#################################### Gravitee.IO Gateway - Configuration ###################################
+############################################################################################################
+
+############################################################################################################
+# This file is the general configuration of Gravitee.IO Gateway:
+# - Properties (and respective default values) in comment are provided for information.
+# - You can reference other property by using ${property.name} syntax
+# - gravitee.home property is automatically set-up by launcher and refers to the installation path. Do not override it !
+#
+# Please have a look to http://docs.gravitee.io/ for more options and fine-grained granularity
+############################################################################################################
+
+# Gateway HTTP server
+#http:
+#  port: 8092
+#  host: 0.0.0.0
+#  idleTimeout: 0
+#  tcpKeepAlive: true
+#  compressionSupported: false
+#  maxHeaderSize: 8192
+#  maxChunkSize: 8192
+#  maxInitialLineLength: 4096
+#  instances: 0
+#  requestTimeout: 0 (in Jupiter mode, default is 30_000 ms)
+#  The following is only used in Jupiter mode. It represents the maximum delay to let the response's platform flows execute properly in case of error during the previous phases.
+#  It's configures a timeout from the max between (requestTimeout - api elapsed time) and requestTimeoutGraceDelay.
+#  requestTimeoutGraceDelay: 30
+#  secured: false
+#  alpn: false
+#  ssl:
+#    clientAuth: none # Supports none, request, requires
+#    tlsProtocols: TLSv1.2, TLSv1.3
+#    tlsCiphers: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+#    keystore:
+#      type: jks # Supports jks, pem, pkcs12, self-signed
+#      path: ${gravitee.home}/security/keystore.jks # A path is required if certificate's type is jks or pkcs12
+#      certificates: # Certificates are required if keystore's type is pem
+#        - cert: ${gravitee.home}/security/mycompany.org.pem
+#          key: ${gravitee.home}/security/mycompany.org.key
+#        - cert: ${gravitee.home}/security/mycompany.com.pem
+#          key: ${gravitee.home}/security/mycompany.com.key
+#      password: secret
+#    truststore:
+#      type: jks # Supports jks, pem, pkcs12, self-signed
+#      path: ${gravitee.home}/security/truststore.jks
+#      password: secret
+#    sni: false
+#    openssl: false # Used to rely on OpenSSL Engine instead of default JDK SSL Engine
+#  websocket:
+#    enabled: false
+#    subProtocols: v10.stomp, v11.stomp, v12.stomp
+#    perMessageWebSocketCompressionSupported: true
+#    perFrameWebSocketCompressionSupported: true
+#  haproxy: # Support for https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+#    proxyProtocol: false
+#    proxyProtocolTimeout: 10000
+
+# Plugins repository
+#plugins:
+#  path:
+#    - ${gravitee.home}/plugins
+#    - ${gravitee.home}/my-custom-plugins
+
+# If a plugin is already installed (but with a different version), management node does not start anymore
+#  failOnDuplicate: true
+
+# Management repository is used to store global configuration such as APIs, applications, apikeys, ...
+# If you use a JDBC repository, we recommend disabling liquibase scripts execution by the Gateway. Let the Management API do it.
+# management:
+#   type: jdbc
+#   jdbc:
+#     liquibase: false
+
+# This is the default configuration using MongoDB (single server)
+# For more information about MongoDB configuration, please have a look to:
+# - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html
+management:
+  type: mongodb                  # repository type
+  mongodb:                       # mongodb repository
+#    prefix:                      # collections prefix
+    dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
+    host: ${ds.mongodb.host}     # mongodb host (default localhost)
+    port: ${ds.mongodb.port}     # mongodb port (default 27017)
+
+## Client settings
+#    description:                 # mongodb description (default gravitee.io)
+#    username:                    # mongodb username (default null)
+#    password:                    # mongodb password (default null)
+#    authSource:                  # mongodb authentication source (when at least a user or a password is defined, default gravitee)
+#    retryWrites:                 # mongodb retriable writes (default true)
+#    readPreference:              # possible values are 'nearest', 'primary', 'primaryPreferred', 'secondary', 'secondaryPreferred'
+#    readPreferenceTags:          # list of read preference tags (https://docs.mongodb.com/manual/core/read-preference-tags/#std-label-replica-set-read-preference-tag-sets)
+### Write concern
+#    writeConcern:               # possible values are 1,2,3... (the number of node) or 'majority' (default is 1)
+#    wtimeout:                   # (default is 0)
+#    journal:                    # (default is true)
+
+## Socket settings
+#    connectTimeout:              # mongodb connection timeout (default 1000)
+#    socketTimeout:               # mongodb socket timeout (default 1000)
+
+## Cluster settings
+#    serverSelectionTimeout:      # mongodb server selection timeout (default 1000)
+#    localThreshold:              # mongodb local threshold (default 15)
+
+## Connection pool settings
+#    maxWaitTime:                 # mongodb max wait time (default 120000)
+#    maxConnectionLifeTime:       # mongodb max connection life time (default 0)
+#    maxConnectionIdleTime:       # mongodb max connection idle time (default 0)
+#    connectionsPerHost:          # mongodb max connections per host (default 100)
+#    minConnectionsPerHost:       # mongodb min connections per host (default 0)
+
+## Server settings
+#    heartbeatFrequency:          # mongodb heartbeat frequency (default 10000)
+#    minHeartbeatFrequency:       # mongodb min heartbeat frequency (default 500)
+
+## SSL settings
+#    sslEnabled:                  # mongodb ssl mode (default false)
+#    tlsProtocol:                 # protocol to use when connecting to the mongodb instance (when sslEnabled is true, default TLS)
+#    keystore:
+#      path:                      # Path to the keystore (when sslEnabled is true, default null)
+#      type:                      # Type of the keystore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)
+#      password:                  # KeyStore password (when sslEnabled is true, default null)
+#      keyPassword:               # Password for recovering keys in the KeyStore (when sslEnabled is true, default null)
+#    truststore:
+#      path:                      # Path to the truststore (when sslEnabled is true, default null)
+#      type:                      # Type of the truststore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)
+#      password:                  # Truststore password (when sslEnabled is true, default null)
+# Management repository: single MongoDB using URI
+# For more information about MongoDB configuration using URI, please have a look to:
+# - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/ConnectionString.html
+#management:
+#  type: mongodb
+#  mongodb:
+#    uri: mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+
+# Management repository: clustered MongoDB
+#management:
+#  type: mongodb
+#  mongodb:
+#    servers:
+#      - host: mongo1
+#        port: 27017
+#      - host: mongo2
+#        port: 27017
+#    dbname: ${ds.mongodb.dbname}
+#    connectTimeout: 500
+#    socketTimeout: 250
+
+# When defining rate-limiting policy, the gateway has to store data to share with other gateway instances.
+# In this example, we are using MongoDB to store counters.
+ratelimit:
+  type: mongodb
+  mongodb:
+    uri: mongodb://${ds.mongodb.host}:${ds.mongodb.port}/${ds.mongodb.dbname}
+
+cache:
+  type: ehcache
+
+# Reporters configuration (used to store reporting monitoring data, request metrics, healthchecks and others...
+# All reporters are enabled by default. To stop one of them, you have to add the property 'enabled: false'
+reporters:
+  # logging configuration
+#  logging:
+#    max_size: -1 # max size per API log content respectively : client-request, client-response, proxy-request and proxy-response in MB (-1 means no limit)
+#    excluded_response_types: video.*|audio.*|image.*|application\/octet-stream|application\/pdf # Response content types to exclude in logging (must be a regular expression)
+  # Elasticsearch reporter
+  elasticsearch:
+    enabled: true # Is the reporter enabled or not (default to true)
+    endpoints:
+      - http://${ds.elastic.host}:${ds.elastic.port}
+#    lifecycle:
+#      policy_property_name: index.lifecycle.name   #for openDistro, use 'opendistro.index_state_management.policy_id' instead of 'index.lifecycle.name'
+#      policies:
+#        monitor: my_policy ## ILM policy for the gravitee-monitor-* indexes
+#        request: my_policy ## ILM policy for the gravitee-request-* indexes
+#        health: my_policy ## ILM policy for the gravitee-health-* indexes
+#        log: my_policy ## ILM policy for the gravitee-log-* indexes
+#    index: gravitee
+#    index_per_type: true
+#    index_mode: daily         # "daily" indexes, suffixed with date. Or "ilm" managed indexes, without date
+#    bulk:
+#      actions: 1000           # Number of requests action before flush
+#      flush_interval: 5       # Flush interval in seconds
+#    settings:
+#      number_of_shards: 1
+#      number_of_replicas: 1
+#      refresh_interval: 5s
+#    pipeline:
+#      plugins:
+#        ingest: geoip, user_agent      # geoip and user_agent are enabled by default
+#    security:
+#      username: user
+#      password: secret
+#    http:
+#      timeout: 30000 # in milliseconds
+#      proxy:
+#        type: HTTP #HTTP, SOCK4, SOCK5
+#        http:
+#          host: localhost
+#          port: 3128
+#          username: user
+#          password: secret
+#        https:
+#          host: localhost
+#          port: 3128
+#          username: user
+#          password: secret
+#    template_mapping:
+#      path: ${gravitee.home}/config/reporter/elasticsearch/templates
+#      extended_request_mapping: request.ftl
+  file:
+    enabled: false # Is the reporter enabled or not (default to false)
+#    fileName: ${gravitee.home}/metrics/%s-yyyy_mm_dd
+#    output: json # Can be csv, json, elasticsearch or message_pack
+#    request: # (Following mapping section is also available for other types: node, health-check, log)
+#     exclude: # Can be a wildcard (ie '*') to exclude all fields (supports json path)
+#       - response-time
+#       - log.clientRequest
+#     include: # Only if exclude is used (supports json path)
+#       - api
+#     rename: # (supports json path)
+#       application: app
+#       request.ip: address
+
+# Gateway service configurations. Provided values are default values.
+# All services are enabled by default. To stop one of them, you have to add the property 'enabled: false' (See the
+# 'local' service for an example).
+services:
+  core:
+    http:
+      enabled: true
+      port: 18082
+      host: localhost
+      authentication:
+        # authentication type to be used for the core services
+        # - none : to disable authentication
+        # - basic : to use basic authentication
+        # default is "basic"
+        type: basic
+        users:
+          admin: adminadmin
+
+  # The thresholds to determine if a probe is healthy or not
+#  health:
+#    threshold:
+#      cpu: # Default is 80%
+#      memory: # Default is 80%
+
+  # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
+  # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API
+  # and management UI
+  sync:
+    # Synchronization is done each 5 seconds
+    delay: 5000
+    unit: MILLISECONDS
+    distributed: false # By enabling this mode, data synchronization process is distributed over clustered API gateways.
+    bulk_items: 100 # Defines the number of items to retrieve during synchronization (events, plans, api keys, ...).
+
+     # [Alpha] Enable Kubernetes Synchronization
+     # This sync service requires to install Gravitee Kubernetes Operator
+#    kubernetes:
+#      enabled: false
+
+  # Local registry service.
+  # This registry is used to load API Definition with json format from the file system. By doing so, you do not need
+  # to configure your API using the web console or the rest API (but you need to know and understand the json descriptor
+  # format to make it work....)
+  local:
+    enabled: false
+    path: ${gravitee.home}/apis # The path to API descriptors
+
+  # Gateway monitoring service.
+  # This service retrieves metrics like os / process / jvm metrics and send them to an underlying reporting service.
+  monitoring:
+    delay: 5000
+    unit: MILLISECONDS
+    distributed: false # By enabling this mode, data monitoring gathering process is distributed over clustered API gateways.
+
+  # metrics service
+  metrics:
+    enabled: false
+# default: local, http_method, http_code
+#    labels:
+#      - local
+#      - remote
+#      - http_method
+#      - http_code
+#      - http_path
+    prometheus:
+      enabled: true
+
+  # heartbeat
+#  heartbeat:
+#    enabled: true
+#    delay: 5000
+#    unit: MILLISECONDS
+#    storeSystemProperties: true
+
+  tracing:
+    enabled: false
+    type: jaeger
+    jaeger:
+      host: localhost
+      port: 14250
+#      ssl:
+#        enabled: false
+
+#handlers:
+#  request:
+#    # manage traceparent header defined by W3C trace-context specification
+#    trace-context:
+#      enabled: false
+#    # possible values: hex, uuid. Default: uuid.
+#    format: uuid
+#    transaction:
+#      # Default: X-Gravitee-Transaction-Id.
+#      header: X-Gravitee-Transaction-Id
+#    headers:
+#      # Override X-Forwarded-Prefix with context path. Disabled by default.
+#      x-forwarded-prefix: false
+#    request:
+#      # Default: X-Gravitee-Request-Id.
+#      header: X-Gravitee-Request-Id
+
+# Referenced properties
+ds:
+  mongodb:
+    dbname: gravitee
+    host: localhost
+    port: 27017
+  elastic:
+    host: localhost
+    port: 9200
+
+#system:
+#  # Proxy configuration that can be used to proxy request to api endpoints (see endpoint http configuration -> Use system proxy).
+#  proxy:
+#    type: HTTP #HTTP, SOCK4, SOCK5
+#    host: localhost
+#    port: 3128
+#    username: user
+#    password: secret
+
+# Organizations and Environments configuration
+# Associate this gateway to a list of environments belonging to organizations. This is a list of environment hrids.
+#organizations: mycompany
+#environments: dev,qa
+
+# Sharding tags configuration
+# Allows to define inclusion/exclusion sharding tags to only deploy a part of APIs. To exclude just prefix the tag with '!'.
+#tags: products,stocks,!international
+#zone: national-products
+
+# Multi-tenant configuration
+# Allow only a single-value
+#tenant: europe
+
+#policy:
+# Customize the api-key header and / or query parameter.
+# Set an empty value to prohibit its use.
+#  api-key:
+#    header: X-Gravitee-Api-Key
+#    param: api-key
+
+#el:
+  # Allows to define which methods or classes are accessible to the Expression Language engine (/!\ caution, changing default whitelist may expose you to security issues).
+  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-expression-language/master/src/main/resources/whitelist).
+#  whitelist:
+    # Allows to define if the specified list of method or classes should be append to the default one or should replace it.
+    # We recommend you to always choose 'append' unless you absolutely know what you are doing.
+#    mode: append
+    # Define the list of classes or methods to append (or set) to made accessible to the Expression Language.
+    # start with 'method' to allow a specific method (complete signature).
+    # start with 'class' to allow a complete class. All methods of the class will then be accessible.
+#    list:
+      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+      # Ex: allow access to all methods of DateTimeFormatter class
+      # - class java.time.format.DateTimeFormatter
+
+#groovy:
+  # Allows to define which methods, fields, constructors, annotations or classes are accessible to the Groovy Script (/!\ caution, changing default whitelist may expose you to security issues).
+  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-policy-groovy/master/src/main/resources/groovy-whitelist).
+#  whitelist:
+    # Allows to define if the specified list of methods, fields, constructors or classes should be append to the default one or should replace it.
+    # We recommend you to always choose 'append' unless you absolutely know what you are doing.
+#    mode: append
+    # Define the list of classes, methods, constructors, fields or annotations to append (or set) to made accessible to the Groovy Script.
+    # start with 'method' to allow a specific method (complete signature).
+    # start with 'class' to allow a complete class. All methods, constructors and fields of the class will then be accessible.
+    # start with 'new' to allow a specific constructor (complete signature).
+    # start with 'field' to allow access to a specific field of a class.
+    # start with 'annotation' to allow use of a specific annotation.
+#    list:
+      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+      # Ex: allow access to all methods, constructors and fields of DateTimeFormatter class
+      # - class java.time.format.DateTimeFormatter
+      # Ex: allow usage of field Integer.MAX_VALUE
+      # - field java.lang.Integer MAX_VALUE
+      # Ex: allow usage of @Override annotation
+      # - annotation java.lang.Override
+
+# If you want to create cluster of nodes, you can change the Hazelcast file to configure the Hz network
+# Clustering capabilities can be used for:
+#   - Distributed sync process
+#   - Distributed rate-limiting / quota counters
+#cluster:
+#  hazelcast:
+#    config:
+#      path: ${gravitee.home}/config/hazelcast.xml
+
+# Configuration of geoip (requires geoip-plugin)
+#geoip:
+#  database:
+#    city:
+#      filename: /path/to/GeoLite2-City.mmdb #if null defaults to the embedded db
+#      watch: true  #if null defaults to false
+#      cache:
+#        capacity: 8200  #if null defaults to 4096
+
+api:
+  # Encrypt API properties using this secret
+  properties:
+    encryption:
+      secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6
+  # when an API is un-deployed (either because it has been stopped or because it has restarted due to a configuration
+  # change), this timeout will be the maximum time (in milliseconds) to wait for all pending requests to terminate
+#  pending_requests_timeout: 10000
+
+# Graceful shutdown.
+#gracefulShutdown:
+  # Default delay is 0 but it can be useful to set it to an adequate value depending on how much time the load balancer takes to stop routing traffic to a gateway instance which is shutting down.
+  # When SIGTERM is sent to the gateway, the shutdown process begin, each client will be explicitly asked for closing connection and the shutdown delay will be applied.
+  # The shutdown delay should allow enough time to client to close their current active connections and create new one. In the same time the load balancer should progressively stop routing traffic to the gateway.
+  # After the delay is expired, the gateway continue the shutdown process. Any pending request will have a chance to finish gracefully and the gateway will stop normally unless it takes too much time and a SIGKILL signal is sent to the gateway.
+#  delay: 0
+#  unit: MILLISECONDS
+
+# Since v3.15.0, a new internal classloader used to load api policies is in place.
+# Setting it to true will switch back to the legacy mode used prior the v3.15.0.
+classloader:
+  legacy:
+    enabled: false
+
+alerts:
+  alert-engine:
+    enabled: true
+    engines:
+      default:
+        endpoints:
+          - https://alert-engine-1:8072/
+        security:
+          username: admin
+          password: adminadmin
+        ssl:
+          keystore:
+            type: jks # Supports jks, pem, pkcs12
+            path: /secure/keystore.jks
+            password: unsecure
+          truststore:
+            type: jks # Supports jks, pem, pkcs12
+            path: /secure/keystore.jks
+            password: unsecure
+    ws:
+      sendEventsOnHttp: false

--- a/docker/integration-tests/one-apim_two-ae/gateway_gravitee_2.yml
+++ b/docker/integration-tests/one-apim_two-ae/gateway_gravitee_2.yml
@@ -1,0 +1,484 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+############################################################################################################
+#################################### Gravitee.IO Gateway - Configuration ###################################
+############################################################################################################
+
+############################################################################################################
+# This file is the general configuration of Gravitee.IO Gateway:
+# - Properties (and respective default values) in comment are provided for information.
+# - You can reference other property by using ${property.name} syntax
+# - gravitee.home property is automatically set-up by launcher and refers to the installation path. Do not override it !
+#
+# Please have a look to http://docs.gravitee.io/ for more options and fine-grained granularity
+############################################################################################################
+
+# Gateway HTTP server
+#http:
+#  port: 8092
+#  host: 0.0.0.0
+#  idleTimeout: 0
+#  tcpKeepAlive: true
+#  compressionSupported: false
+#  maxHeaderSize: 8192
+#  maxChunkSize: 8192
+#  maxInitialLineLength: 4096
+#  instances: 0
+#  requestTimeout: 0 (in Jupiter mode, default is 30_000 ms)
+#  The following is only used in Jupiter mode. It represents the maximum delay to let the response's platform flows execute properly in case of error during the previous phases.
+#  It's configures a timeout from the max between (requestTimeout - api elapsed time) and requestTimeoutGraceDelay.
+#  requestTimeoutGraceDelay: 30
+#  secured: false
+#  alpn: false
+#  ssl:
+#    clientAuth: none # Supports none, request, requires
+#    tlsProtocols: TLSv1.2, TLSv1.3
+#    tlsCiphers: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+#    keystore:
+#      type: jks # Supports jks, pem, pkcs12, self-signed
+#      path: ${gravitee.home}/security/keystore.jks # A path is required if certificate's type is jks or pkcs12
+#      certificates: # Certificates are required if keystore's type is pem
+#        - cert: ${gravitee.home}/security/mycompany.org.pem
+#          key: ${gravitee.home}/security/mycompany.org.key
+#        - cert: ${gravitee.home}/security/mycompany.com.pem
+#          key: ${gravitee.home}/security/mycompany.com.key
+#      password: secret
+#    truststore:
+#      type: jks # Supports jks, pem, pkcs12, self-signed
+#      path: ${gravitee.home}/security/truststore.jks
+#      password: secret
+#    sni: false
+#    openssl: false # Used to rely on OpenSSL Engine instead of default JDK SSL Engine
+#  websocket:
+#    enabled: false
+#    subProtocols: v10.stomp, v11.stomp, v12.stomp
+#    perMessageWebSocketCompressionSupported: true
+#    perFrameWebSocketCompressionSupported: true
+#  haproxy: # Support for https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+#    proxyProtocol: false
+#    proxyProtocolTimeout: 10000
+
+# Plugins repository
+#plugins:
+#  path:
+#    - ${gravitee.home}/plugins
+#    - ${gravitee.home}/my-custom-plugins
+
+# If a plugin is already installed (but with a different version), management node does not start anymore
+#  failOnDuplicate: true
+
+# Management repository is used to store global configuration such as APIs, applications, apikeys, ...
+# If you use a JDBC repository, we recommend disabling liquibase scripts execution by the Gateway. Let the Management API do it.
+# management:
+#   type: jdbc
+#   jdbc:
+#     liquibase: false
+
+# This is the default configuration using MongoDB (single server)
+# For more information about MongoDB configuration, please have a look to:
+# - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html
+management:
+  type: mongodb                  # repository type
+  mongodb:                       # mongodb repository
+#    prefix:                      # collections prefix
+    dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
+    host: ${ds.mongodb.host}     # mongodb host (default localhost)
+    port: ${ds.mongodb.port}     # mongodb port (default 27017)
+
+## Client settings
+#    description:                 # mongodb description (default gravitee.io)
+#    username:                    # mongodb username (default null)
+#    password:                    # mongodb password (default null)
+#    authSource:                  # mongodb authentication source (when at least a user or a password is defined, default gravitee)
+#    retryWrites:                 # mongodb retriable writes (default true)
+#    readPreference:              # possible values are 'nearest', 'primary', 'primaryPreferred', 'secondary', 'secondaryPreferred'
+#    readPreferenceTags:          # list of read preference tags (https://docs.mongodb.com/manual/core/read-preference-tags/#std-label-replica-set-read-preference-tag-sets)
+### Write concern
+#    writeConcern:               # possible values are 1,2,3... (the number of node) or 'majority' (default is 1)
+#    wtimeout:                   # (default is 0)
+#    journal:                    # (default is true)
+
+## Socket settings
+#    connectTimeout:              # mongodb connection timeout (default 1000)
+#    socketTimeout:               # mongodb socket timeout (default 1000)
+
+## Cluster settings
+#    serverSelectionTimeout:      # mongodb server selection timeout (default 1000)
+#    localThreshold:              # mongodb local threshold (default 15)
+
+## Connection pool settings
+#    maxWaitTime:                 # mongodb max wait time (default 120000)
+#    maxConnectionLifeTime:       # mongodb max connection life time (default 0)
+#    maxConnectionIdleTime:       # mongodb max connection idle time (default 0)
+#    connectionsPerHost:          # mongodb max connections per host (default 100)
+#    minConnectionsPerHost:       # mongodb min connections per host (default 0)
+
+## Server settings
+#    heartbeatFrequency:          # mongodb heartbeat frequency (default 10000)
+#    minHeartbeatFrequency:       # mongodb min heartbeat frequency (default 500)
+
+## SSL settings
+#    sslEnabled:                  # mongodb ssl mode (default false)
+#    tlsProtocol:                 # protocol to use when connecting to the mongodb instance (when sslEnabled is true, default TLS)
+#    keystore:
+#      path:                      # Path to the keystore (when sslEnabled is true, default null)
+#      type:                      # Type of the keystore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)
+#      password:                  # KeyStore password (when sslEnabled is true, default null)
+#      keyPassword:               # Password for recovering keys in the KeyStore (when sslEnabled is true, default null)
+#    truststore:
+#      path:                      # Path to the truststore (when sslEnabled is true, default null)
+#      type:                      # Type of the truststore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)
+#      password:                  # Truststore password (when sslEnabled is true, default null)
+# Management repository: single MongoDB using URI
+# For more information about MongoDB configuration using URI, please have a look to:
+# - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/ConnectionString.html
+#management:
+#  type: mongodb
+#  mongodb:
+#    uri: mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+
+# Management repository: clustered MongoDB
+#management:
+#  type: mongodb
+#  mongodb:
+#    servers:
+#      - host: mongo1
+#        port: 27017
+#      - host: mongo2
+#        port: 27017
+#    dbname: ${ds.mongodb.dbname}
+#    connectTimeout: 500
+#    socketTimeout: 250
+
+# When defining rate-limiting policy, the gateway has to store data to share with other gateway instances.
+# In this example, we are using MongoDB to store counters.
+ratelimit:
+  type: mongodb
+  mongodb:
+    uri: mongodb://${ds.mongodb.host}:${ds.mongodb.port}/${ds.mongodb.dbname}
+
+cache:
+  type: ehcache
+
+# Reporters configuration (used to store reporting monitoring data, request metrics, healthchecks and others...
+# All reporters are enabled by default. To stop one of them, you have to add the property 'enabled: false'
+reporters:
+  # logging configuration
+#  logging:
+#    max_size: -1 # max size per API log content respectively : client-request, client-response, proxy-request and proxy-response in MB (-1 means no limit)
+#    excluded_response_types: video.*|audio.*|image.*|application\/octet-stream|application\/pdf # Response content types to exclude in logging (must be a regular expression)
+  # Elasticsearch reporter
+  elasticsearch:
+    enabled: true # Is the reporter enabled or not (default to true)
+    endpoints:
+      - http://${ds.elastic.host}:${ds.elastic.port}
+#    lifecycle:
+#      policy_property_name: index.lifecycle.name   #for openDistro, use 'opendistro.index_state_management.policy_id' instead of 'index.lifecycle.name'
+#      policies:
+#        monitor: my_policy ## ILM policy for the gravitee-monitor-* indexes
+#        request: my_policy ## ILM policy for the gravitee-request-* indexes
+#        health: my_policy ## ILM policy for the gravitee-health-* indexes
+#        log: my_policy ## ILM policy for the gravitee-log-* indexes
+#    index: gravitee
+#    index_per_type: true
+#    index_mode: daily         # "daily" indexes, suffixed with date. Or "ilm" managed indexes, without date
+#    bulk:
+#      actions: 1000           # Number of requests action before flush
+#      flush_interval: 5       # Flush interval in seconds
+#    settings:
+#      number_of_shards: 1
+#      number_of_replicas: 1
+#      refresh_interval: 5s
+#    pipeline:
+#      plugins:
+#        ingest: geoip, user_agent      # geoip and user_agent are enabled by default
+#    security:
+#      username: user
+#      password: secret
+#    http:
+#      timeout: 30000 # in milliseconds
+#      proxy:
+#        type: HTTP #HTTP, SOCK4, SOCK5
+#        http:
+#          host: localhost
+#          port: 3128
+#          username: user
+#          password: secret
+#        https:
+#          host: localhost
+#          port: 3128
+#          username: user
+#          password: secret
+#    template_mapping:
+#      path: ${gravitee.home}/config/reporter/elasticsearch/templates
+#      extended_request_mapping: request.ftl
+  file:
+    enabled: false # Is the reporter enabled or not (default to false)
+#    fileName: ${gravitee.home}/metrics/%s-yyyy_mm_dd
+#    output: json # Can be csv, json, elasticsearch or message_pack
+#    request: # (Following mapping section is also available for other types: node, health-check, log)
+#     exclude: # Can be a wildcard (ie '*') to exclude all fields (supports json path)
+#       - response-time
+#       - log.clientRequest
+#     include: # Only if exclude is used (supports json path)
+#       - api
+#     rename: # (supports json path)
+#       application: app
+#       request.ip: address
+
+# Gateway service configurations. Provided values are default values.
+# All services are enabled by default. To stop one of them, you have to add the property 'enabled: false' (See the
+# 'local' service for an example).
+services:
+  core:
+    http:
+      enabled: true
+      port: 18082
+      host: localhost
+      authentication:
+        # authentication type to be used for the core services
+        # - none : to disable authentication
+        # - basic : to use basic authentication
+        # default is "basic"
+        type: basic
+        users:
+          admin: adminadmin
+
+  # The thresholds to determine if a probe is healthy or not
+#  health:
+#    threshold:
+#      cpu: # Default is 80%
+#      memory: # Default is 80%
+
+  # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
+  # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API
+  # and management UI
+  sync:
+    # Synchronization is done each 5 seconds
+    delay: 5000
+    unit: MILLISECONDS
+    distributed: false # By enabling this mode, data synchronization process is distributed over clustered API gateways.
+    bulk_items: 100 # Defines the number of items to retrieve during synchronization (events, plans, api keys, ...).
+
+     # [Alpha] Enable Kubernetes Synchronization
+     # This sync service requires to install Gravitee Kubernetes Operator
+#    kubernetes:
+#      enabled: false
+
+  # Local registry service.
+  # This registry is used to load API Definition with json format from the file system. By doing so, you do not need
+  # to configure your API using the web console or the rest API (but you need to know and understand the json descriptor
+  # format to make it work....)
+  local:
+    enabled: false
+    path: ${gravitee.home}/apis # The path to API descriptors
+
+  # Gateway monitoring service.
+  # This service retrieves metrics like os / process / jvm metrics and send them to an underlying reporting service.
+  monitoring:
+    delay: 5000
+    unit: MILLISECONDS
+    distributed: false # By enabling this mode, data monitoring gathering process is distributed over clustered API gateways.
+
+  # metrics service
+  metrics:
+    enabled: false
+# default: local, http_method, http_code
+#    labels:
+#      - local
+#      - remote
+#      - http_method
+#      - http_code
+#      - http_path
+    prometheus:
+      enabled: true
+
+  # heartbeat
+#  heartbeat:
+#    enabled: true
+#    delay: 5000
+#    unit: MILLISECONDS
+#    storeSystemProperties: true
+
+  tracing:
+    enabled: false
+    type: jaeger
+    jaeger:
+      host: localhost
+      port: 14250
+#      ssl:
+#        enabled: false
+
+#handlers:
+#  request:
+#    # manage traceparent header defined by W3C trace-context specification
+#    trace-context:
+#      enabled: false
+#    # possible values: hex, uuid. Default: uuid.
+#    format: uuid
+#    transaction:
+#      # Default: X-Gravitee-Transaction-Id.
+#      header: X-Gravitee-Transaction-Id
+#    headers:
+#      # Override X-Forwarded-Prefix with context path. Disabled by default.
+#      x-forwarded-prefix: false
+#    request:
+#      # Default: X-Gravitee-Request-Id.
+#      header: X-Gravitee-Request-Id
+
+# Referenced properties
+ds:
+  mongodb:
+    dbname: gravitee
+    host: localhost
+    port: 27017
+  elastic:
+    host: localhost
+    port: 9200
+
+#system:
+#  # Proxy configuration that can be used to proxy request to api endpoints (see endpoint http configuration -> Use system proxy).
+#  proxy:
+#    type: HTTP #HTTP, SOCK4, SOCK5
+#    host: localhost
+#    port: 3128
+#    username: user
+#    password: secret
+
+# Organizations and Environments configuration
+# Associate this gateway to a list of environments belonging to organizations. This is a list of environment hrids.
+#organizations: mycompany
+#environments: dev,qa
+
+# Sharding tags configuration
+# Allows to define inclusion/exclusion sharding tags to only deploy a part of APIs. To exclude just prefix the tag with '!'.
+#tags: products,stocks,!international
+#zone: national-products
+
+# Multi-tenant configuration
+# Allow only a single-value
+#tenant: europe
+
+#policy:
+# Customize the api-key header and / or query parameter.
+# Set an empty value to prohibit its use.
+#  api-key:
+#    header: X-Gravitee-Api-Key
+#    param: api-key
+
+#el:
+  # Allows to define which methods or classes are accessible to the Expression Language engine (/!\ caution, changing default whitelist may expose you to security issues).
+  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-expression-language/master/src/main/resources/whitelist).
+#  whitelist:
+    # Allows to define if the specified list of method or classes should be append to the default one or should replace it.
+    # We recommend you to always choose 'append' unless you absolutely know what you are doing.
+#    mode: append
+    # Define the list of classes or methods to append (or set) to made accessible to the Expression Language.
+    # start with 'method' to allow a specific method (complete signature).
+    # start with 'class' to allow a complete class. All methods of the class will then be accessible.
+#    list:
+      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+      # Ex: allow access to all methods of DateTimeFormatter class
+      # - class java.time.format.DateTimeFormatter
+
+#groovy:
+  # Allows to define which methods, fields, constructors, annotations or classes are accessible to the Groovy Script (/!\ caution, changing default whitelist may expose you to security issues).
+  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-policy-groovy/master/src/main/resources/groovy-whitelist).
+#  whitelist:
+    # Allows to define if the specified list of methods, fields, constructors or classes should be append to the default one or should replace it.
+    # We recommend you to always choose 'append' unless you absolutely know what you are doing.
+#    mode: append
+    # Define the list of classes, methods, constructors, fields or annotations to append (or set) to made accessible to the Groovy Script.
+    # start with 'method' to allow a specific method (complete signature).
+    # start with 'class' to allow a complete class. All methods, constructors and fields of the class will then be accessible.
+    # start with 'new' to allow a specific constructor (complete signature).
+    # start with 'field' to allow access to a specific field of a class.
+    # start with 'annotation' to allow use of a specific annotation.
+#    list:
+      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+      # Ex: allow access to all methods, constructors and fields of DateTimeFormatter class
+      # - class java.time.format.DateTimeFormatter
+      # Ex: allow usage of field Integer.MAX_VALUE
+      # - field java.lang.Integer MAX_VALUE
+      # Ex: allow usage of @Override annotation
+      # - annotation java.lang.Override
+
+# If you want to create cluster of nodes, you can change the Hazelcast file to configure the Hz network
+# Clustering capabilities can be used for:
+#   - Distributed sync process
+#   - Distributed rate-limiting / quota counters
+#cluster:
+#  hazelcast:
+#    config:
+#      path: ${gravitee.home}/config/hazelcast.xml
+
+# Configuration of geoip (requires geoip-plugin)
+#geoip:
+#  database:
+#    city:
+#      filename: /path/to/GeoLite2-City.mmdb #if null defaults to the embedded db
+#      watch: true  #if null defaults to false
+#      cache:
+#        capacity: 8200  #if null defaults to 4096
+
+api:
+  # Encrypt API properties using this secret
+  properties:
+    encryption:
+      secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6
+  # when an API is un-deployed (either because it has been stopped or because it has restarted due to a configuration
+  # change), this timeout will be the maximum time (in milliseconds) to wait for all pending requests to terminate
+#  pending_requests_timeout: 10000
+
+# Graceful shutdown.
+#gracefulShutdown:
+  # Default delay is 0 but it can be useful to set it to an adequate value depending on how much time the load balancer takes to stop routing traffic to a gateway instance which is shutting down.
+  # When SIGTERM is sent to the gateway, the shutdown process begin, each client will be explicitly asked for closing connection and the shutdown delay will be applied.
+  # The shutdown delay should allow enough time to client to close their current active connections and create new one. In the same time the load balancer should progressively stop routing traffic to the gateway.
+  # After the delay is expired, the gateway continue the shutdown process. Any pending request will have a chance to finish gracefully and the gateway will stop normally unless it takes too much time and a SIGKILL signal is sent to the gateway.
+#  delay: 0
+#  unit: MILLISECONDS
+
+# Since v3.15.0, a new internal classloader used to load api policies is in place.
+# Setting it to true will switch back to the legacy mode used prior the v3.15.0.
+classloader:
+  legacy:
+    enabled: false
+
+alerts:
+  alert-engine:
+    enabled: true
+    engines:
+      default:
+        endpoints:
+          - https://alert-engine-2:8072/
+        security:
+          username: admin
+          password: adminadmin
+        ssl:
+          keystore:
+            type: jks # Supports jks, pem, pkcs12
+            path: /secure/keystore.jks
+            password: unsecure
+          truststore:
+            type: jks # Supports jks, pem, pkcs12
+            path: /secure/keystore.jks
+            password: unsecure
+    ws:
+      sendEventsOnHttp: true

--- a/docker/integration-tests/one-apim_two-ae/generate-keystores.sh
+++ b/docker/integration-tests/one-apim_two-ae/generate-keystores.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+generate_keystores_and_certificate() {
+  cat <<EOF
+##################################
+###  Generate all certificats  ###
+##################################
+EOF
+
+  for alias in "${aliases[@]}"; do
+    echo "Generate keypair and cert for ${alias}"
+
+    keytool -genkeypair -keyalg RSA \
+      -alias "${alias}" \
+      -dname CN="${alias}" \
+      -keypass unsecure \
+      -storepass unsecure \
+      -keystore "keystore-${alias}.jks"
+
+    keytool -exportcert \
+      -alias "${alias}" \
+      -file "${alias}.pem" \
+      -rfc \
+      -storepass unsecure \
+      -keystore "keystore-${alias}.jks"
+  done
+}
+
+import_each_cert_in_each_keystore() {
+  echo "###  import all cert in each keystore  ###"
+
+  for alias_keystore in "${aliases[@]}"; do
+    for alias_cert in "${aliases[@]}"; do
+      if [[ "${alias_keystore}" != "${alias_cert}" ]]; then
+        echo "import ${alias_cert}.pem into keystore-${alias_keystore}.jks"
+        keytool -importcert -v \
+          -file "${alias_cert}.pem" \
+          -alias "${alias_cert}" \
+          -noprompt \
+          -trustcacerts \
+          -storepass unsecure \
+          -keystore "keystore-${alias_keystore}.jks"
+      fi
+    done
+  done
+}
+
+show_keystores() {
+  cat <<EOF
+##################################
+###        Show results        ###
+##################################
+EOF
+
+  for keystore in keystore*.jks; do
+    echo "###  ${keystore}  ###"
+    keytool -list -storepass unsecure -keystore "${keystore}"
+    echo ""
+  done
+}
+
+generate_multiple_keystores() {
+  generate_keystores_and_certificate
+  import_each_cert_in_each_keystore
+  show_keystores
+}
+
+generate_one_for_all_keystore() {
+  for alias in "${aliases[@]}"; do
+    echo "Generate keypair and cert for ${alias}"
+    keytool -genkeypair -keyalg RSA \
+      -alias "${alias}" \
+      -dname CN="${alias}" \
+      -keypass unsecure \
+      -storepass unsecure \
+      -keystore "keystore.jks"
+  done
+
+  # Hack - to keep same docker-compose volume mount, we make copy of the keystore with each named
+  for alias in "${aliases[@]}"; do
+    cp "keystore.jks" "keystore-${alias}.jks"
+  done
+}
+
+### main ###
+aliases=(alert-engine-1 alert-engine-2 management-api gateway-1 gateway-2)
+mkdir -p keystores
+
+pushd keystores >/dev/null
+  generate_multiple_keystores
+#  generate_one_for_all_keystore
+popd >/dev/null

--- a/docker/integration-tests/one-apim_two-ae/management-api_gravitee.yml
+++ b/docker/integration-tests/one-apim_two-ae/management-api_gravitee.yml
@@ -1,0 +1,630 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+############################################################################################################
+################################ Gravitee.IO Management API - Configuration ################################
+############################################################################################################
+
+############################################################################################################
+# This file is the general configuration of Gravitee.IO Management API:
+# - Properties (and respective default values) in comment are provided for information.
+# - You can reference other property by using ${property.name} syntax
+# - gravitee.home property is automatically set-up by launcher and refers to the installation path. Do not override it !
+#
+# Please have a look to http://docs.gravitee.io/ for more options and fine-grained granularity
+############################################################################################################
+
+# Console settings
+#console:
+## Specify the URL of the Management API and UI of this instance, mandatory if you want to connect it to Cockpit
+#  ui:
+#    url: http://localhost:3000
+#  api:
+#    url: http://localhost:8083/management
+
+## Pendo Analysis Tool
+# To make our SaaS offering easier to use, we now have the ability to track activity in Pendo. This is disabled by
+# default, but if you'd like to help us in this journey, don't hesitate to reach us to get our key ;)
+#  analytics:
+#    pendo:
+#      enabled: false
+#      apiKey: 'myKey'
+
+## Console dashboards
+#  dashboards:
+#    path: ${gravitee.home}/dashboards
+
+# HTTP Server
+#jetty:
+#  IP/hostname to bind to. Default is 0.0.0.0
+#  host: 0.0.0.0
+#  port: 8083
+#  idleTimeout: 30000
+#  acceptors: -1
+#  selectors: -1
+#  pool:
+#    minThreads: 10
+#    maxThreads: 200
+#    idleTimeout: 60000
+#    queueSize: 6000
+#  jmx: false
+#  statistics: false
+#  accesslog:
+#    enabled: true
+#    path: ${gravitee.home}/logs/gravitee_accesslog_yyyy_mm_dd.log
+#  secured: false
+#  ssl:
+#    keystore:
+#      type: jks # Supports jks, pkcs12
+#      path: ${gravitee.home}/security/keystore.jks
+#      password: secret
+#    truststore:
+#      type: jks # Supports jks, pkcs12
+#      path: ${gravitee.home}/security/truststore.jks
+#      password: secret
+
+http:
+  api:
+    # Configure the listening path for the API. Default to /
+#    entrypoint: /
+    # Configure Management API and Portal API.
+#    management:
+#      enabled: true
+#      entrypoint: ${http.api.entrypoint}management
+#      cors:
+# Allows to configure the header Access-Control-Allow-Origin (default value: *)
+# '*' is a valid value but is considered as a security risk as it will be opened to cross origin requests from anywhere.
+#        allow-origin: '*'
+# Allows to define how long the result of the preflight request should be cached for (default value; 1728000 [20 days])
+#        max-age: 1728000
+# Which methods to allow (default value: OPTIONS, GET, POST, PUT, DELETE)
+#        allow-methods: 'OPTIONS, GET, POST, PUT, DELETE'
+# Which headers to allow (default values: Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, X-Xsrf-Token)
+#        allow-headers: 'Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, X-Xsrf-Token'
+#  Allows to configure the header Access-Control-Expose-Headers
+#        exposed-headers: 'ETag;X-Xsrf-Token'
+#    portal:
+#      enabled: true
+#      entrypoint: ${http.api.entrypoint}portal
+#      cors:
+# Allows to configure the header Access-Control-Allow-Origin (default value: *)
+# '*' is a valid value but is considered as a security risk as it will be opened to cross origin requests from anywhere.
+#        allow-origin: '*'
+# Allows to define how long the result of the preflight request should be cached for (default value; 1728000 [20 days])
+#        max-age: 1728000
+# Which methods to allow (default value: OPTIONS, GET, POST, PUT, DELETE)
+#        allow-methods: 'OPTIONS, GET, POST, PUT, DELETE'
+# Which headers to allow (default values: Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, X-Xsrf-Token)
+#        allow-headers: 'Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, X-Xsrf-Token'
+#  Allows to configure the header Access-Control-Expose-Headers
+#        exposed-headers: 'ETag;X-Xsrf-Token'
+  csrf:
+    # Allows to enable or disable the CSRF protection. Enabled by default.
+    enabled: true
+  hsts:
+    enabled: true
+    include-sub-domains: true
+    max-age: 31536000
+
+# Plugins repository
+#plugins:
+#  path:
+#    - ${gravitee.home}/plugins
+#    - ${gravitee.home}/my-custom-plugins
+# If a external is already installed (but with a different version), management node does not start anymore
+#  failOnDuplicate: true
+
+# Management repository is used to store global configuration such as APIs, applications, apikeys, ...
+# This is the default configuration using MongoDB (single server)
+# For more information about MongoDB configuration, please have a look to:
+# - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html
+management:
+  type: mongodb                  # repository type
+  mongodb:                       # mongodb repository
+#    prefix:                      # collections prefix
+    dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
+    host: ${ds.mongodb.host}     # mongodb host (default localhost)
+    port: ${ds.mongodb.port}     # mongodb port (default 27017)
+
+## Client settings
+#    description:                 # mongodb description (default gravitee.io)
+#    username:                    # mongodb username (default null)
+#    password:                    # mongodb password (default null)
+#    authSource:                  # mongodb authentication source (when at least a user or a password is defined, default gravitee)
+#    retryWrites:                 # mongodb retriable writes (default true)
+#    readPreference:              # possible values are 'nearest', 'primary', 'primaryPreferred', 'secondary', 'secondaryPreferred'
+#    readPreferenceTags:          # list of read preference tags (https://docs.mongodb.com/manual/core/read-preference-tags/#std-label-replica-set-read-preference-tag-sets)
+### Write concern
+#    writeConcern:               # possible values are 1,2,3... (the number of node) or 'majority' (default is 1)
+#    wtimeout:                   # (default is 0)
+#    journal:                    # (default is true)
+
+## Socket settings
+#    connectTimeout:              # mongodb connection timeout (default 1000)
+#    socketTimeout:               # mongodb socket timeout (default 1000)
+
+## Cluster settings
+#    serverSelectionTimeout:      # mongodb server selection timeout (default 1000)
+#    localThreshold:              # mongodb local threshold (default 15)
+
+## Connection pool settings
+#    maxWaitTime:                 # mongodb max wait time (default 120000)
+#    maxConnectionLifeTime:       # mongodb max connection life time (default 0)
+#    maxConnectionIdleTime:       # mongodb max connection idle time (default 0)
+#    connectionsPerHost:          # mongodb max connections per host (default 100)
+#    minConnectionsPerHost:       # mongodb min connections per host (default 0)
+
+## Server settings
+#    heartbeatFrequency:          # mongodb heartbeat frequency (default 10000)
+#    minHeartbeatFrequency:       # mongodb min heartbeat frequency (default 500)
+
+## SSL settings
+#    sslEnabled:                  # mongodb ssl mode (default false)
+#    sslInvalidHostNameAllowed:   # mongodb ssl allow invalid host name (default false)
+#    tlsProtocol:                 # protocol to use when connecting to the mongodb instance (when sslEnabled is true, default TLS)
+#    keystore:
+#      path:                      # Path to the keystore (when sslEnabled is true, default null)
+#      type:                      # Type of the keystore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)
+#      password:                  # KeyStore password (when sslEnabled is true, default null)
+#      keyPassword:               # Password for recovering keys in the KeyStore (when sslEnabled is true, default null)
+#    truststore:
+#      path:                      # Path to the truststore (when sslEnabled is true, default null)
+#      type:                      # Type of the truststore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)
+#      password:                  # Truststore password (when sslEnabled is true, default null)
+# Management repository: single MongoDB using URI
+# For more information about MongoDB configuration using URI, please have a look to:
+# - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/ConnectionString.html
+#management:
+#  type: mongodb
+#  mongodb:
+#    uri: mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+
+# Management repository: clustered MongoDB
+#management:
+#  type: mongodb
+#  mongodb:
+#    servers:
+#      - host: mongo1
+#        port: 27017
+#      - host: mongo2
+#        port: 27017
+#    dbname: ${ds.mongodb.dbname}
+#    connectTimeout: 500
+#    socketTimeout: 250
+
+services:
+  core:
+    http:
+      enabled: true
+      port: 18083
+      host: localhost
+      authentication:
+        # authentication type to be used for the core services
+        # - none : to disable authentication
+        # - basic : to use basic authentication
+        # default is "basic"
+        type: basic
+        users:
+          admin: adminadmin
+
+  # metrics service
+  metrics:
+    enabled: false
+    prometheus:
+      enabled: true
+
+  # v3 upgrader service. Can be disabled after first launch.
+  v3-upgrader:
+    enabled: true
+  # AutoFetch service. (since 3.2)
+  # Use to fetch periodically documentation pages.
+  auto_fetch:
+    enabled: true
+    cron: "0 */5 * * * *"
+
+  # Subscription service
+  subscription:
+    enabled: true
+    #  Pre-expiration notification, number of days before the expiration an email should be send to subscriber and primary owner
+    pre-expiration-notification-schedule: 90,45,30
+
+
+# Analytics repository is used to store all reporting, metrics, health-checks stored by gateway instances
+# This is the default configuration using Elasticsearch
+analytics:
+  type: elasticsearch
+  elasticsearch:
+    endpoints:
+      - http://${ds.elastic.host}:${ds.elastic.port}
+#    index: gravitee
+#    index_per_type: true
+#    index_mode: daily    # "daily" indexes, suffixed with date. Or "ilm" managed indexes, without date
+#    cross_cluster:
+#      mapping:
+#        tenant_id: cluster_name
+#        tenant_id: cluster_name
+#    security:
+#      username: user
+#      password: secret
+#    http:
+#      timeout: 10000 # in milliseconds
+#      proxy:
+#        type: HTTP #HTTP, SOCK4, SOCK5
+#        http:
+#          host: localhost
+#          port: 3128
+#          username: user
+#          password: secret
+#        https:
+#          host: localhost
+#          port: 3128
+#          username: user
+#          password: secret
+
+# Authentication and identity sources
+# Users can have following roles (authorities):
+#  USER: Can access portal and be a member of an API
+#  API_PUBLISHER: Can create and manage APIs
+#  API_CONSUMER: Can create and manage Applications
+#  ADMIN: Can manage global system
+security:
+  # When using an authentication providers, use trustAll mode for TLS connections
+  # trustAll: false
+  providers:  # authentication providers
+    - type: memory
+      # allow search results to display the user email. Be careful, It may be contrary to the user privacy.
+#      allow-email-in-search-results: true
+      # password encoding/hashing algorithm. One of:
+      # - bcrypt : passwords are hashed with bcrypt (supports only $2a$ algorithm)
+      # - none : passwords are not hashed/encrypted
+      # default value is bcrypt
+      password-encoding-algo: bcrypt
+      users:
+        - user:
+          username: user
+          #firstname:
+          #lastname:
+          # Passwords are encoded using BCrypt
+          # Password value: password
+          password: $2a$10$9kjw/SH9gucCId3Lnt6EmuFreUAcXSZgpvAYuW2ISv7hSOhHRH1AO
+          roles: ORGANIZATION:USER,ENVIRONMENT:USER
+          # Useful to receive notifications
+          #email:
+        - user:
+          username: admin
+          #firstname:
+          #lastname:
+          # Password value: admin
+          password: $2a$10$Ihk05VSds5rUSgMdsMVi9OKMIx2yUvMz7y9VP3rJmQeizZLrhLMyq
+          roles: ORGANIZATION:ADMIN,ENVIRONMENT:ADMIN
+          #email:
+        - user:
+          username: api1
+          #firstname:
+          #lastname:
+          # Password value: api1
+          password: $2a$10$iXdXO4wAYdhx2LOwijsp7.PsoAZQ05zEdHxbriIYCbtyo.y32LTji
+          # You can declare multiple roles using comma separator
+          roles: ORGANIZATION:USER,ENVIRONMENT:API_PUBLISHER
+          #email:
+        - user:
+          username: application1
+          #firstname:
+          #lastname:
+          # Password value: application1
+          password: $2a$10$2gtKPYRB9zaVaPcn5RBx/.3T.7SeZoDGs9GKqbo9G64fKyXFR1He.
+          roles: ORGANIZATION:USER,ENVIRONMENT:USER
+          #email:
+    # Enable authentication using internal repository
+    - type: gravitee
+      # allow search results to display the user email. Be careful, It may be contrary to the user privacy.
+#      allow-email-in-search-results: true
+    # Enable authentication using an LDAP/Active Directory
+#    - type: ldap
+      # This is default LDAP configuration for ApacheDS
+#      context:
+#        username: "uid=admin,ou=system"
+#        password: "secret"
+#        url: "ldap://localhost:10389/c=io,o=gravitee"
+#        base: "c=io,o=gravitee" # the context source base
+#      authentication:
+#        user:
+          # Search base for user authentication. Defaults to "". Only used with user filter.
+          # It should be relative to the Base DN. If the whole DN is o=user accounts,c=io,o=gravitee then the base should be like this:
+#          base: "o=user accounts"
+          # The LDAP filter used to search for user during authentication. For example "(uid={0})". The substituted parameter is the user's login name.
+#          filter: "mail={0}"
+          # Specifies the attribute name which contains the user photo (URL or binary)
+#          photo-attribute: "jpegPhoto"
+#        group:
+          # Search base for groups searches. Defaults to "". Only used with group filter.
+          # It should be relative to the Base DN. If the whole DN is o=authorization groups,c=io,o=gravitee then the base should be like this:
+#          base: "o=authorization groups"
+#          filter: "member={0}"
+#          role:
+#            attribute: "cn"
+#            mapper: {
+#              GRAVITEE-CONSUMERS: API_CONSUMER,
+#              GRAVITEE-PUBLISHERS: API_PUBLISHER,
+#              GRAVITEE-ADMINS: ADMIN,
+#              GRAVITEE-USERS: USER
+#            }
+#      lookup:
+         # allow search results to display the user email. Be careful, It may be contrary to the user privacy.
+#         allow-email-in-search-results: true
+#        user:
+          # Search base for user searches. Defaults to "". Only used with user filter.
+          # It should be relative to the Base DN. If the whole DN is o=user accounts,c=io,o=gravitee then the base should be like this:
+#          base: "o=user accounts"
+          # The LDAP filter used to search for user during authentication. For example "(uid={0})". The substituted parameter is the user's login name.
+#          filter: "(&(objectClass=Person)(|(cn=*{0}*)(uid={0})))"
+
+# Define absolute path for the a default API icon (png format)
+# If not define, an API without icon with display a random image
+#configuration:
+#  default-api-icon:
+
+# SMTP configuration used to send mails
+email:
+  enabled: false
+  host: smtp.my.domain
+  subject: "[Gravitee.io] %s"
+  port: 587
+  from: noreply@my.domain
+#  username: user@my.domain
+#  password: password
+#  properties:
+#    auth: true
+#    starttls.enable: true
+#    ssl.trust: smtp.gmail.com
+
+# Mail templates
+#templates:
+#  path: ${gravitee.home}/templates
+
+#portal:
+#  themes:
+#    path: ${gravitee.home}/themes
+  # Allows domains to be used while generating some emails from the portal. ie. registration, forget password
+  # Empty whitelist means all urls are allowed.
+#  whitelist:
+#    - https://portal.domain.com
+#    - https://private-portal.domain.com
+
+# Referenced properties
+ds:
+  mongodb:
+    dbname: gravitee
+    host: localhost
+    port: 27017
+  elastic:
+    host: localhost
+    port: 9200
+
+jwt:
+  secret: myJWT4Gr4v1t33_S3cr3t
+  # Allows to define the end of validity of the token in seconds (default 604800 = a week)
+  #expire-after: 604800
+  # Allows to define the end of validity of the token in seconds for email registration (default 86400 = a day)
+  #email-registration-expire-after: 86400
+  # Allows to define issuer (default gravitee-management-auth)
+  #issuer: gravitee-management-auth
+  # Allows to define cookie context path (default /)
+  #cookie-path: /
+  # Allows to define cookie domain (default "")
+  #cookie-domain: .gravitee.io
+  # Allows to define if cookie secure only (default false)
+  #cookie-secure: true
+
+swagger:
+  # Default scheme used when creating an API from a Swagger descriptor if there is no scheme specified.
+  scheme: https
+
+# User management configuration
+user:
+  login:
+    # Create a default application when user connects to the portal for the very first time (default true)
+    #defaultApplication: true
+
+  # Password complexity validation policy
+  # Applications should enforce password complexity rules to discourage easy to guess passwords.
+  # Passwords should require a minimum level of complexity that makes sense for the application and its user population.
+  password:
+    policy:
+      # Regex pattern for password validation (default to OWASP recommendations).
+      # 8 to 32 characters, no more than 2 consecutive equal characters, min 1 special characters (@ & # ...), min 1 upper case character.
+      pattern: ^(?:(?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))(?!.*(.)\1{2,})[A-Za-z0-9!~<>,;:_\-=?*+#."'&§`£€%°()\\\|\[\]\-\$\^\@\/]{8,32}$
+              # Example : ^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=])(?=\S+$).{8,}$
+              # ^                # start-of-string
+              #(?=.*[0-9])       # a digit must occur at least once
+              #(?=.*[a-z])       # a lower case letter must occur at least once
+              #(?=.*[A-Z])       # an upper case letter must occur at least once
+              #(?=.*[@#$%^&+=])  # a special character must occur at least once
+              #(?=\S+$)          # no whitespace allowed in the entire string
+              #.{8,}             # anything, at least eight places though
+              #$                 # end-of-string
+  creation:
+    token:
+      #expire-after: 86400
+  reference:
+      # Secret key used to generate reference of a user which is unique (default: s3cR3t4grAv1t33.1Ous3D4R3f3r3nc3)
+      # Must contains 32 chars (256 bits)
+      #secret:
+  anonymize-on-delete:
+    #enabled: false
+
+# Enable / disable documentation sanitize. Enabled by default.
+documentation:
+  markdown:
+    sanitize: true
+
+#imports:
+  # Enable / disable import from private hosts. Enabled by default. (See https://en.wikipedia.org/wiki/Private_network)
+#  allow-from-private: true
+  # Empty whitelist means all urls are allowed. Note: allow-from-private is ignored when whitelist is defined.
+#  whitelist:
+#      - https://whitelist.domain1.com
+#      - https://restricted.domain2.com/whitelisted/path
+
+search:
+  data: ${gravitee.home}/data
+
+# global configuration of the http client
+#httpClient:
+#  timeout: 10000 # in milliseconds
+#  proxy:
+#    exclude-hosts: # list of hosts to exclude from proxy (wildcard hosts are supported)
+#      - '*.internal.com'
+#      - internal.mycompany.com
+#    type: HTTP #HTTP, SOCK4, SOCK5
+#    http:
+#      host: localhost
+#      port: 3128
+#      username: user
+#      password: secret
+#    https:
+#      host: localhost
+#      port: 3128
+#      username: user
+#      password: secret
+
+notifiers:
+  email:
+    enabled: true
+    host: ${email.host}
+    subject: ${email.subject}
+    port: ${email.port}
+#    username: ${email.username}
+#    password: ${email.password}
+#    starttls.enabled: false
+##   Authentication method restrictions for the notifier
+##   possible values are: XOAUTH2,NTLM,DIGEST-MD5,CRAM-SHA256,CRAM-SHA1,CRAM-MD5,LOGIN,PLAIN
+##   when not set, all authMethods are selected
+#    authMethods: LOGIN,PLAIN
+#    ssl:
+#      trustAll: false
+#      keyStore:
+#      keyStorePassword:
+#  webhook:
+#    enabled: true
+    # Empty whitelist means all urls are allowed.
+#    whitelist:
+#      - https://whitelist.domain1.com
+#      - https://restricted.domain2.com/whitelisted/path
+
+# Allows to enable or disable recaptcha (see https://developers.google.com/recaptcha/docs/v3). Currently, it only affect the user registration route.
+#reCaptcha:
+#  enabled: false
+#  siteKey:
+#  secretKey:
+#  minScore: 0.5
+#  serviceUrl: https://www.google.com/recaptcha/api/siteverify
+
+#el:
+  # Allows to define which methods or classes are accessible to the Expression Language engine (/!\ caution, changing default whitelist may expose you to security issues).
+  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-expression-language/master/src/main/resources/whitelist).
+#  whitelist:
+    # Allows to define if the specified list of method or classes should be append to the default one or should replace it.
+    # We recommend you to always choose 'append' unless you absolutely kwnow what you are doing.
+#    mode: append
+    # Define the list of classes or methods to append (or set) to made accessible to the Expression Language.
+    # start with 'method' to allow a specific method (complete signature).
+    # start with 'class' to allow a complete class. All methods of the class will then be accessible.
+#    list:
+      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+      # Ex: allow access to all methods of DateTimeFormatter class
+      # - class java.time.format.DateTimeFormatter
+
+#groovy:
+  # Allows to define which methods, fields, constructors, annotations or classes are accessible to the Groovy Script (/!\ caution, changing default whitelist may expose you to security issues).
+  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-policy-groovy/master/src/main/resources/groovy-whitelist).
+#  whitelist:
+    # Allows to define if the specified list of methods, fields, constructors or classes should be append to the default one or should replace it.
+    # We recommend you to always choose 'append' unless you absolutely know what you are doing.
+#    mode: append
+    # Define the list of classes, methods, constructors, fields or annotations to append (or set) to made accessible to the Groovy Script.
+    # start with 'method' to allow a specific method (complete signature).
+    # start with 'class' to allow a complete class. All methods, constructors and fields of the class will then be accessible.
+    # start with 'new' to allow a specific constructor (complete signature).
+    # start with 'field' to allow access to a specific field of a class.
+    # start with 'annotation' to allow use of a specific annotation.
+#    list:
+      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+      # Ex: allow access to all methods, constructors and fields of DateTimeFormatter class
+      # - class java.time.format.DateTimeFormatter
+      # Ex: allow usage of field Integer.MAX_VALUE
+      # - field java.lang.Integer MAX_VALUE
+      # Ex: allow usage of @Override annotation
+      # - annotation java.lang.Override
+
+# Allows to enable or disable the 'Subscribe to newsletter' feature when user completes his profile on first log in. Default is enabled.
+#newsletter:
+#  enabled: true
+
+# Specify the visibility duration of a gateway in Unknown State (in seconds)
+# Default : 604800 seconds (7 days)
+#gateway:
+#  unknown-expire-after: 604800
+
+# Cockpit
+# Specify the URL to cockpit instance. Default is the Gravitee SAAS instance
+#cockpit:
+#  url: https://cockpit.gravitee.io
+
+api:
+  # Encrypt API properties using this secret
+  properties:
+    encryption:
+      secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6
+
+alerts:
+  alert-engine:
+    enabled: true
+    engines:
+      cluster1:
+        endpoints:
+          - https://alert-engine-2:8072/
+        security:
+          username: admin
+          password: adminadmin
+        ssl:
+          keystore:
+            type: jks # Supports jks, pem, pkcs12
+            path: /secure/keystore.jks
+            password: unsecure
+          truststore:
+            type: jks # Supports jks, pem, pkcs12
+            path: /secure/keystore.jks
+            password: unsecure
+      default:
+        endpoints:
+          - https://alert-engine-1:8072/
+        security:
+          username: admin
+          password: adminadmin
+        ssl:
+          keystore:
+            type: jks # Supports jks, pem, pkcs12
+            path: /secure/keystore.jks
+            password: unsecure
+          truststore:
+            type: jks # Supports jks, pem, pkcs12
+            path: /secure/keystore.jks
+            password: unsecure
+    ws:
+      sendEventsOnHttp: false

--- a/docker/integration-tests/one-apim_two-ae/readme.adoc
+++ b/docker/integration-tests/one-apim_two-ae/readme.adoc
@@ -1,0 +1,87 @@
+= Use case : one APIM and two AE
+
+This use case show how to configure two AE with secure connection configured with an APIM.
+
+== Setup
+
+=== Generate keystore
+
+We need a keystore to configure TLS connexion between component. Here, for convenience, we create only one keystore used by all component.
+
+To generate certificate in the keystores:
+
+[source,bash]
+----
+./generate-keystores.sh
+----
+
+=== Build the application
+
+The `alert-engine-connector-ws` plugin must be build to be able to use it in APIM gateways and Management APIs. It is used by a volume mount in docker-compose file.
+
+To build the plugin locally, from the root folder of the repo:
+
+[source,bash]
+----
+mvn clean verify
+----
+
+=== Environment variable
+
+You should create an environment file `.env` at least to define the path to your gravitee licence (needed to use Alert-Engine).
+
+You can create one from the template and *update it*:
+
+[source,bash]
+----
+cp .env.template .env
+----
+
+
+== Run
+
+Everything is defined between compose file and configuration file. To run it just do:
+
+[source,bash]
+----
+docker compose up -d
+----
+
+Afterward, you can login to the management UI via http://localhost:8080 with default credentials (admin:admin) and run a test case:
+
+. In the organization setting, enable Alert-Engine
+. create an API `echo` witch target https://api.gravitee.io/echo
+. add an alert: In the `echo` API settings, on `Alert` sub-menu:
++
+----
+Alert when a metric of the request validates a condition
+Metrics     : Response time
+Type        : Threshold
+Operator    : less than
+Threshold   : 20000
+----
+
+. get the IP addresse of gateways and call the `echo` api:
++
+[source, bash]
+----
+while read -r container_id
+do
+  container_ip="$(docker inspect "${container_id}" | jq -r '.[0].NetworkSettings.Networks|to_entries[0].value.IPAddress')"
+  echo -e "\n\n${container_id} ip: ${container_ip}"
+  curl -k "http://${container_ip}:8082/echo"
+done < <(docker compose ps --format json gateway-1 gateway-2 |jq -r '.[].Name')
+----
+. Finally, go to the `History` pane in the `Alert` menu of `echo` api and see the notification triggered by AE.
+
+
+== Annexe - useful commands
+
+[source, bash]
+----
+openssl s_client -connect alert-engine-1:8072 -showcerts </dev/null | openssl x509 -noout -subject
+
+keytool -exportcert -alias alert-engine-1 -file ae1.pem -rfc -storepass unsecure -keystore /secure/keystore.jks
+
+curl --cacert ae1.pem -Iv --user 'admin:adminadmin' 'https://alert-engine-1:8072/http/trigger'
+----

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/EngineSecurity.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/EngineSecurity.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.configuration;
+
+import java.util.Objects;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class EngineSecurity {
+
+    private String username;
+    private String password;
+
+    public EngineSecurity(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String value) {
+        this.username = value;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String value) {
+        this.password = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EngineSecurity security = (EngineSecurity) o;
+        return Objects.equals(username, security.username) && Objects.equals(password, security.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(username, password);
+    }
+}

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/EngineSsl.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/EngineSsl.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.ae.connector.ws.configuration;
+
+import java.util.List;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class EngineSsl {
+
+    /**
+     * Alert Engine ssl keystore type. (jks, pkcs12,)
+     */
+    private String keystoreType;
+
+    /**
+     * Alert Engine ssl keystore path.
+     */
+    private String keystorePath;
+
+    /**
+     * Alert Engine ssl keystore password.
+     */
+    private String keystorePassword;
+
+    /**
+     * Alert Engine ssl pem certs paths
+     */
+    private List<String> keystorePemCerts;
+
+    /**
+     * Alert Engine ssl pem keys paths
+     */
+    private List<String> keystorePemKeys;
+
+    /**
+     * Alert Engine ssl truststore trustall.
+     */
+    private boolean trustAll;
+
+    /**
+     * Alert Engine ssl truststore hostname verifier.
+     */
+    private boolean hostnameVerifier;
+
+    /**
+     * Alert Engine ssl truststore type.
+     */
+    private String truststoreType;
+
+    /**
+     * Alert Engine ssl truststore path.
+     */
+    private String truststorePath;
+
+    /**
+     * Alert Engine ssl truststore password.
+     */
+    private String truststorePassword;
+
+    public String getKeystoreType() {
+        return keystoreType;
+    }
+
+    public EngineSsl setKeystoreType(String keystoreType) {
+        this.keystoreType = keystoreType;
+        return this;
+    }
+
+    public String getKeystorePath() {
+        return keystorePath;
+    }
+
+    public EngineSsl setKeystorePath(String keystorePath) {
+        this.keystorePath = keystorePath;
+        return this;
+    }
+
+    public String getKeystorePassword() {
+        return keystorePassword;
+    }
+
+    public EngineSsl setKeystorePassword(String keystorePassword) {
+        this.keystorePassword = keystorePassword;
+        return this;
+    }
+
+    public List<String> getKeystorePemCerts() {
+        return keystorePemCerts;
+    }
+
+    public EngineSsl setKeystorePemCerts(List<String> keystorePemCerts) {
+        this.keystorePemCerts = keystorePemCerts;
+        return this;
+    }
+
+    public List<String> getKeystorePemKeys() {
+        return keystorePemKeys;
+    }
+
+    public EngineSsl setKeystorePemKeys(List<String> keystorePemKeys) {
+        this.keystorePemKeys = keystorePemKeys;
+        return this;
+    }
+
+    public boolean isTrustAll() {
+        return trustAll;
+    }
+
+    public EngineSsl setTrustAll(boolean trustAll) {
+        this.trustAll = trustAll;
+        return this;
+    }
+
+    public boolean isHostnameVerifier() {
+        return hostnameVerifier;
+    }
+
+    public EngineSsl setHostnameVerifier(boolean hostnameVerifier) {
+        this.hostnameVerifier = hostnameVerifier;
+        return this;
+    }
+
+    public String getTruststoreType() {
+        return truststoreType;
+    }
+
+    public EngineSsl setTruststoreType(String truststoreType) {
+        this.truststoreType = truststoreType;
+        return this;
+    }
+
+    public String getTruststorePath() {
+        return truststorePath;
+    }
+
+    public EngineSsl setTruststorePath(String truststorePath) {
+        this.truststorePath = truststorePath;
+        return this;
+    }
+
+    public String getTruststorePassword() {
+        return truststorePassword;
+    }
+
+    public EngineSsl setTruststorePassword(String truststorePassword) {
+        this.truststorePassword = truststorePassword;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EngineSsl engineSsl = (EngineSsl) o;
+        return (
+            trustAll == engineSsl.trustAll &&
+            hostnameVerifier == engineSsl.hostnameVerifier &&
+            Objects.equals(keystoreType, engineSsl.keystoreType) &&
+            Objects.equals(keystorePath, engineSsl.keystorePath) &&
+            Objects.equals(keystorePassword, engineSsl.keystorePassword) &&
+            Objects.equals(keystorePemCerts, engineSsl.keystorePemCerts) &&
+            Objects.equals(keystorePemKeys, engineSsl.keystorePemKeys) &&
+            Objects.equals(truststoreType, engineSsl.truststoreType) &&
+            Objects.equals(truststorePath, engineSsl.truststorePath) &&
+            Objects.equals(truststorePassword, engineSsl.truststorePassword)
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            keystoreType,
+            keystorePath,
+            keystorePassword,
+            keystorePemCerts,
+            keystorePemKeys,
+            trustAll,
+            hostnameVerifier,
+            truststoreType,
+            truststorePath,
+            truststorePassword
+        );
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/AE-46

**Description**

This PR allows the configuration for multi alert engines located in different location.
It only allows to push Triggers in different locations. Events are sent on the default channel.

**How to Test**

1. Create yourself a keystore for your local environment

```bash
keytool -selfcert -alias mycert -keystore keystore.jks
```
Anything regarding full name or organisation just put `localhost`

2. Configure 2 Alert Engines with SSL configuration

```yaml
ingesters:
  ws:
    #    instances: 0
    #    port: 8072
    #    host: 0.0.0.0
    secured: true
    alpn: true
    ssl:
      clientAuth: false
      keystore:
        type: jks # Supports jks, pem, pkcs12
        path: /path/to/keystore.jks
        password: changeit
      truststore:
        type: jks # Supports jks, pem, pkcs12
        path: /path/to/keystore.jks
        password: changeit
    authentication: # authentication type to be used for HTTP authentication
      type: basic # none to disable authentication / basic for basic authentication
      users:
        admin: adminadmin
```

3. Insert this configuration in your APIM Management API

```yaml
alerts:
  alert-engine:
    enabled: true
    engines:
      cluster1:
        endpoints:
          - https://localhost:8072/
        security:
          username: admin
          password: adminadmin
        ssl:
          keystore:
            type: jks # Supports jks, pem, pkcs12
            path: /path/to/keystore.jks
            password: changeit
          truststore:
            type: jks # Supports jks, pem, pkcs12
            path: /path/to/keystore.jks
            password: changeit
      default:
        endpoints:
          - https://localhost:8073/
        security:
          username: admin
          password: adminadmin
        ssl:
          keystore:
            type: jks # Supports jks, pem, pkcs12
            path: /path/to/keystore.jks
            password: changeit
          truststore:
            type: jks # Supports jks, pem, pkcs12
            path: /path/to/keystore.jks
            password: changeit
    ws:
      endpoints:
        - https://localhost:8072/
      security:
        username: admin
        password: adminadmin
      ssl:
        trustall: true
        keystore:
          type: jks # Supports jks, pem, pkcs12
          path: /path/to/keystore.jks
          password: changeit
        truststore:
          type: jks # Supports jks, pem, pkcs12
          path: /path/to/keystore.jks
          password: changeit
```

You should see your APIM connected to all alert engines
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-AE-46-connector-multi-dc-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/ae/gravitee-alert-engine-connectors/2.1.0-AE-46-connector-multi-dc-SNAPSHOT/gravitee-alert-engine-connectors-2.1.0-AE-46-connector-multi-dc-SNAPSHOT.zip)
  <!-- Version placeholder end -->
