### PR TITLE
feat(deps): upgrade gravitee dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,32 +4,32 @@ version: 2.1
 setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@2.5
+    gravitee: gravitee-io/gravitee@4.12.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
 workflows:
-  setup_build:
-    when:
-      not: << pipeline.git.tag >>
-    jobs:
-      - gravitee/setup_plugin-build-config:
-          filters:
-            tags:
-              ignore:
-                - /.*/
+    setup_build:
+        when:
+            not: << pipeline.git.tag >>
+        jobs:
+            - gravitee/setup_plugin-build-config:
+                  filters:
+                      tags:
+                          ignore:
+                              - /.*/
 
-  setup_release:
-    when:
-      matches:
-        pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
-        value: << pipeline.git.tag >>
-    jobs:
-      - gravitee/setup_plugin-release-config:
-          filters:
-            branches:
-              ignore:
-                - /.*/
-            tags:
-              only:
-                - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/
+    setup_release:
+        when:
+            matches:
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
+                value: << pipeline.git.tag >>
+        jobs:
+            - gravitee/setup_plugin-release-config:
+                  filters:
+                      branches:
+                          ignore:
+                              - /.*/
+                      tags:
+                          only:
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,12 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
-    }
-  ]
+    "dependencyDashboard": true,
+    "extends": ["config:base", "schedule:earlyMondays"],
+    "prConcurrentLimit": 3,
+    "rebaseWhen": "conflicted",
+    "packageRules": [
+        {
+            "matchDatasources": ["orb"],
+            "rangeStrategy": "replace"
+        }
+    ]
 }

--- a/docker/integration-tests/one-apim_two-ae/alert-engine_gravitee_1.yml
+++ b/docker/integration-tests/one-apim_two-ae/alert-engine_gravitee_1.yml
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,61 +28,61 @@
 
 # Ingesters
 ingesters:
-  ws:
-    instances: 0
-    port: 8072
-    host: alert-engine-1
-    secured: true
-    alpn: false
-    ssl:
-      clientAuth: false
-      keystore:
-        type: jks # Supports jks, pem, pkcs12
-        path: /secure/keystore.jks
-        password: unsecure
-      truststore:
-        type: jks # Supports jks, pem, pkcs12
-        path: /secure/keystore.jks
-        password: unsecure
-    authentication: # authentication type to be used for HTTP authentication
-      type: basic # none to disable authentication / basic for basic authentication
-      users:
-        admin: adminadmin
+    ws:
+        instances: 0
+        port: 8072
+        host: alert-engine-1
+        secured: true
+        alpn: false
+        ssl:
+            clientAuth: false
+            keystore:
+                type: jks # Supports jks, pem, pkcs12
+                path: /secure/keystore.jks
+                password: unsecure
+            truststore:
+                type: jks # Supports jks, pem, pkcs12
+                path: /secure/keystore.jks
+                password: unsecure
+        authentication: # authentication type to be used for HTTP authentication
+            type: basic # none to disable authentication / basic for basic authentication
+            users:
+                admin: adminadmin
 
 # Alert service configurations. Provided values are default values.
 # All services are enabled by default. To stop one of them, you have to add the property 'enabled: false'.
 services:
-  core:
-    http:
-      enabled: true
-      port: 18072
-      host: localhost
-      authentication:
-        # authentication type to be used for the core services
-        # - none : to disable authentication
-        # - basic : to use basic authentication
-        # default is "basic"
-        type: basic
-        users:
-          admin: adminadmin
-  metrics:
-    enabled: false
-    prometheus:
-      enabled: true
+    core:
+        http:
+            enabled: true
+            port: 18072
+            host: localhost
+            authentication:
+                # authentication type to be used for the core services
+                # - none : to disable authentication
+                # - basic : to use basic authentication
+                # default is "basic"
+                type: basic
+                users:
+                    admin: adminadmin
+    metrics:
+        enabled: false
+        prometheus:
+            enabled: true
 
 cluster:
-  sync:
-    time:
-      value: 30
-      unit: SECONDS
+    sync:
+        time:
+            value: 30
+            unit: SECONDS
 
-  hazelcast:
-    # Hazelcast system properties (see https://docs.hazelcast.org/docs/latest/manual/html-single/#system-properties)
-    # Use the same properties without 'hazelcast.' prefix.
-    #systemProperties:
-      # Timeout to wait for a response when a remote call is sent, in milliseconds.
-      #operation.call.timeout.millis: 60000
-      # Socket connection timeout in seconds. Socket.connect() is blocked until either connection is established or connection is refused or this timeout passes. Default is 0, means infinite.
-      #socket.connect.timeout.seconds: 0
-    config:
-      path: ${gravitee.home}/config/hazelcast.xml
+    hazelcast:
+        # Hazelcast system properties (see https://docs.hazelcast.org/docs/latest/manual/html-single/#system-properties)
+        # Use the same properties without 'hazelcast.' prefix.
+        #systemProperties:
+        # Timeout to wait for a response when a remote call is sent, in milliseconds.
+        #operation.call.timeout.millis: 60000
+        # Socket connection timeout in seconds. Socket.connect() is blocked until either connection is established or connection is refused or this timeout passes. Default is 0, means infinite.
+        #socket.connect.timeout.seconds: 0
+        config:
+            path: ${gravitee.home}/config/hazelcast.xml

--- a/docker/integration-tests/one-apim_two-ae/alert-engine_gravitee_2.yml
+++ b/docker/integration-tests/one-apim_two-ae/alert-engine_gravitee_2.yml
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,61 +28,61 @@
 
 # Ingesters
 ingesters:
-  ws:
-    instances: 0
-    port: 8072
-    host: alert-engine-2
-    secured: true
-    alpn: false
-    ssl:
-      clientAuth: false
-      keystore:
-        type: jks # Supports jks, pem, pkcs12
-        path: /secure/keystore.jks
-        password: unsecure
-      truststore:
-        type: jks # Supports jks, pem, pkcs12
-        path: /secure/keystore.jks
-        password: unsecure
-    authentication: # authentication type to be used for HTTP authentication
-      type: basic # none to disable authentication / basic for basic authentication
-      users:
-        admin: adminadmin
+    ws:
+        instances: 0
+        port: 8072
+        host: alert-engine-2
+        secured: true
+        alpn: false
+        ssl:
+            clientAuth: false
+            keystore:
+                type: jks # Supports jks, pem, pkcs12
+                path: /secure/keystore.jks
+                password: unsecure
+            truststore:
+                type: jks # Supports jks, pem, pkcs12
+                path: /secure/keystore.jks
+                password: unsecure
+        authentication: # authentication type to be used for HTTP authentication
+            type: basic # none to disable authentication / basic for basic authentication
+            users:
+                admin: adminadmin
 
 # Alert service configurations. Provided values are default values.
 # All services are enabled by default. To stop one of them, you have to add the property 'enabled: false'.
 services:
-  core:
-    http:
-      enabled: true
-      port: 18072
-      host: localhost
-      authentication:
-        # authentication type to be used for the core services
-        # - none : to disable authentication
-        # - basic : to use basic authentication
-        # default is "basic"
-        type: basic
-        users:
-          admin: adminadmin
-  metrics:
-    enabled: false
-    prometheus:
-      enabled: true
+    core:
+        http:
+            enabled: true
+            port: 18072
+            host: localhost
+            authentication:
+                # authentication type to be used for the core services
+                # - none : to disable authentication
+                # - basic : to use basic authentication
+                # default is "basic"
+                type: basic
+                users:
+                    admin: adminadmin
+    metrics:
+        enabled: false
+        prometheus:
+            enabled: true
 
 cluster:
-  sync:
-    time:
-      value: 30
-      unit: SECONDS
+    sync:
+        time:
+            value: 30
+            unit: SECONDS
 
-  hazelcast:
-    # Hazelcast system properties (see https://docs.hazelcast.org/docs/latest/manual/html-single/#system-properties)
-    # Use the same properties without 'hazelcast.' prefix.
-    #systemProperties:
-      # Timeout to wait for a response when a remote call is sent, in milliseconds.
-      #operation.call.timeout.millis: 60000
-      # Socket connection timeout in seconds. Socket.connect() is blocked until either connection is established or connection is refused or this timeout passes. Default is 0, means infinite.
-      #socket.connect.timeout.seconds: 0
-    config:
-      path: ${gravitee.home}/config/hazelcast.xml
+    hazelcast:
+        # Hazelcast system properties (see https://docs.hazelcast.org/docs/latest/manual/html-single/#system-properties)
+        # Use the same properties without 'hazelcast.' prefix.
+        #systemProperties:
+        # Timeout to wait for a response when a remote call is sent, in milliseconds.
+        #operation.call.timeout.millis: 60000
+        # Socket connection timeout in seconds. Socket.connect() is blocked until either connection is established or connection is refused or this timeout passes. Default is 0, means infinite.
+        #socket.connect.timeout.seconds: 0
+        config:
+            path: ${gravitee.home}/config/hazelcast.xml

--- a/docker/integration-tests/one-apim_two-ae/docker-compose.yml
+++ b/docker/integration-tests/one-apim_two-ae/docker-compose.yml
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,213 +14,212 @@
 # limitations under the License.
 #
 
-version: '3.9'
+version: "3.9"
 
 networks:
-  control-plan:
-  ae-1:
-  ae-2:
+    control-plan:
+    ae-1:
+    ae-2:
 
 volumes:
-  data-elasticsearch:
-  data-mongo:
+    data-elasticsearch:
+    data-mongo:
 
 x-pluginAEconnector: &pluginAEconnector
-  type: bind
-  source: ./../../../gravitee-alert-engine-connector-ws/target/gravitee-ae-connectors-ws-2.0.0.zip
-  target: /opt/graviteeio-gateway/plugins/gravitee-alert-engine-connectors-ws-2.0.0.zip
-  read_only: true
+    type: bind
+    source: ./../../../gravitee-alert-engine-connector-ws/target/gravitee-ae-connectors-ws-2.0.0.zip
+    target: /opt/graviteeio-gateway/plugins/gravitee-alert-engine-connectors-ws-2.0.0.zip
+    read_only: true
 
 services:
+    mongodb:
+        image: mongo:${MONGODB_VERSION:-5}
+        healthcheck:
+            test: ["CMD", "mongo", "--quiet", "localhost/test", "--eval", "quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)"]
+            interval: 20s
+            timeout: 10s
+            retries: 3
+        volumes:
+            - data-mongo:/data/db
+        networks:
+            - control-plan
 
-  mongodb:
-    image: mongo:${MONGODB_VERSION:-5}
-    healthcheck:
-      test: [ "CMD", "mongo", "--quiet", "localhost/test", "--eval", "quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)" ]
-      interval: 20s
-      timeout: 10s
-      retries: 3
-    volumes:
-      - data-mongo:/data/db
-    networks:
-      - control-plan
+    elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+        healthcheck:
+            test: ["CMD", "curl", "-fsSL", "http://localhost:9200/_cat/health?h=status"]
+            interval: 20s
+            timeout: 10s
+            retries: 3
+        volumes:
+            - data-elasticsearch:/usr/share/elasticsearch/data
+        environment:
+            - http.host=0.0.0.0
+            - transport.host=0.0.0.0
+            - xpack.security.enabled=false
+            - xpack.monitoring.enabled=false
+            - cluster.name=elasticsearch
+            - bootstrap.memory_lock=true
+            - discovery.type=single-node
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+            nofile: 65536
+        networks:
+            - control-plan
 
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
-    healthcheck:
-      test: [ "CMD", "curl", "-fsSL", "http://localhost:9200/_cat/health?h=status" ]
-      interval: 20s
-      timeout: 10s
-      retries: 3
-    volumes:
-      - data-elasticsearch:/usr/share/elasticsearch/data
-    environment:
-      - http.host=0.0.0.0
-      - transport.host=0.0.0.0
-      - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
-      - cluster.name=elasticsearch
-      - bootstrap.memory_lock=true
-      - discovery.type=single-node
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile: 65536
-    networks:
-      - control-plan
+    gateway-1:
+        image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
+        healthcheck:
+            test: ["CMD", "curl", "--user", "admin:adminadmin", "--fail", "http://localhost:18082/_node/health"]
+            interval: 20s
+            timeout: 10s
+            retries: 3
+            start_period: 30s
+        depends_on:
+            - mongodb
+            - elasticsearch
+            - alert-engine-1
+            - alert-engine-2
+        volumes:
+            - ${LICENCE_KEY_PATH}:/opt/graviteeio-gateway/license/license.key:ro
+            - ./keystores/keystore-gateway-1.jks:/secure/keystore.jks:ro
+            - ./gateway_gravitee_1.yml:/opt/graviteeio-gateway/config/gravitee.yml:ro
+            - *pluginAEconnector
+        environment:
+            - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+            - gravitee_ratelimit_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+            - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
+            - gravitee_plugins_path_0=$${gravitee.home}/plugins
+        networks:
+            - control-plan
+            - ae-1
 
-  gateway-1:
-    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
-    healthcheck:
-      test: [ "CMD", "curl", "--user", "admin:adminadmin", "--fail", "http://localhost:18082/_node/health" ]
-      interval: 20s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-    depends_on:
-      - mongodb
-      - elasticsearch
-      - alert-engine-1
-      - alert-engine-2
-    volumes:
-      - ${LICENCE_KEY_PATH}:/opt/graviteeio-gateway/license/license.key:ro
-      - ./keystores/keystore-gateway-1.jks:/secure/keystore.jks:ro
-      - ./gateway_gravitee_1.yml:/opt/graviteeio-gateway/config/gravitee.yml:ro
-      - *pluginAEconnector
-    environment:
-      - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
-      - gravitee_ratelimit_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
-      - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
-      - gravitee_plugins_path_0=$${gravitee.home}/plugins
-    networks:
-      - control-plan
-      - ae-1
+    gateway-2:
+        image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
+        healthcheck:
+            test: ["CMD", "curl", "--user", "admin:adminadmin", "--fail", "http://localhost:18082/_node/health"]
+            interval: 20s
+            timeout: 10s
+            retries: 3
+            start_period: 30s
+        depends_on:
+            - mongodb
+            - elasticsearch
+            - alert-engine-1
+            - alert-engine-2
+        volumes:
+            - ${LICENCE_KEY_PATH}:/opt/graviteeio-gateway/license/license.key:ro
+            - ./keystores/keystore-gateway-2.jks:/secure/keystore.jks:ro
+            - ./gateway_gravitee_2.yml:/opt/graviteeio-gateway/config/gravitee.yml:ro
+            - *pluginAEconnector
+        environment:
+            - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+            - gravitee_ratelimit_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+            - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
+            - gravitee_plugins_path_0=$${gravitee.home}/plugins
+        networks:
+            - control-plan
+            - ae-2
 
-  gateway-2:
-    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
-    healthcheck:
-      test: [ "CMD", "curl", "--user", "admin:adminadmin", "--fail", "http://localhost:18082/_node/health" ]
-      interval: 20s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-    depends_on:
-      - mongodb
-      - elasticsearch
-      - alert-engine-1
-      - alert-engine-2
-    volumes:
-      - ${LICENCE_KEY_PATH}:/opt/graviteeio-gateway/license/license.key:ro
-      - ./keystores/keystore-gateway-2.jks:/secure/keystore.jks:ro
-      - ./gateway_gravitee_2.yml:/opt/graviteeio-gateway/config/gravitee.yml:ro
-      - *pluginAEconnector
-    environment:
-      - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
-      - gravitee_ratelimit_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
-      - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
-      - gravitee_plugins_path_0=$${gravitee.home}/plugins
-    networks:
-      - control-plan
-      - ae-2
+    management-api:
+        image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
+        healthcheck:
+            test: ["CMD", "curl", "--user", "admin:adminadmin", "--fail", "http://localhost:18083/_node/health"]
+            interval: 20s
+            timeout: 10s
+            retries: 3
+            start_period: 30s
+        ports:
+            - "8081:8083"
+        links:
+            - mongodb
+            - elasticsearch
+            - alert-engine-1
+            - alert-engine-2
+            - gateway-1
+            - gateway-2
+        depends_on:
+            - mongodb
+            - elasticsearch
+        volumes:
+            - ${LICENCE_KEY_PATH}:/opt/graviteeio-management-api/license/license.key:ro
+            - ./keystores/keystore-management-api.jks:/secure/keystore.jks:ro
+            - ./management-api_gravitee.yml:/opt/graviteeio-management-api/config/gravitee.yml:ro
+            - <<: *pluginAEconnector
+              target: /opt/graviteeio-management-api/plugins/gravitee-alert-engine-connectors-ws-2.0.0.zip
+        environment:
+            - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+            - gravitee_analytics_elasticsearch_endpoints_0=http://elasticsearch:9200
+            - gravitee_plugins_path_0=$${gravitee.home}/plugins
+        networks:
+            - control-plan
+            - ae-1
+            - ae-2
 
-  management-api:
-    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
-    healthcheck:
-      test: [ "CMD", "curl", "--user", "admin:adminadmin", "--fail", "http://localhost:18083/_node/health" ]
-      interval: 20s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-    ports:
-      - "8081:8083"
-    links:
-      - mongodb
-      - elasticsearch
-      - alert-engine-1
-      - alert-engine-2
-      - gateway-1
-      - gateway-2
-    depends_on:
-      - mongodb
-      - elasticsearch
-    volumes:
-      - ${LICENCE_KEY_PATH}:/opt/graviteeio-management-api/license/license.key:ro
-      - ./keystores/keystore-management-api.jks:/secure/keystore.jks:ro
-      - ./management-api_gravitee.yml:/opt/graviteeio-management-api/config/gravitee.yml:ro
-      - <<: *pluginAEconnector
-        target: /opt/graviteeio-management-api/plugins/gravitee-alert-engine-connectors-ws-2.0.0.zip
-    environment:
-      - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
-      - gravitee_analytics_elasticsearch_endpoints_0=http://elasticsearch:9200
-      - gravitee_plugins_path_0=$${gravitee.home}/plugins
-    networks:
-      - control-plan
-      - ae-1
-      - ae-2
+    management-ui:
+        image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
+        ports:
+            - "8080:8080"
+        depends_on:
+            - management-api
+        environment:
+            - MGMT_API_URL=http://localhost:8081/management/organizations/DEFAULT/environments/DEFAULT/
+        networks:
+            - control-plan
 
-  management-ui:
-    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
-    ports:
-      - "8080:8080"
-    depends_on:
-      - management-api
-    environment:
-      - MGMT_API_URL=http://localhost:8081/management/organizations/DEFAULT/environments/DEFAULT/
-    networks:
-      - control-plan
+    alert-engine-1:
+        image: graviteeio/ae-engine:${AE_VERSION:-latest}
+        stop_grace_period: 5m
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://admin:adminadmin@localhost:18072/_node"]
+            interval: 20s
+            timeout: 10s
+            retries: 3
+        deploy:
+            resources:
+                limits:
+                    cpus: "1"
+                    memory: 768M
+                reservations:
+                    cpus: "1"
+                    memory: 512M
+        environment:
+            - JAVA_OPTS=-Dlogging.level.com.graviteesource.ae.cluster.hz.channel.HazelcastChannelManager=DEBUG -Dlogging.level.com.graviteesource.ae.core.listener.EventListenerVerticle=DEBUG
+            - GIO_MIN_MEM=128m
+            - GIO_MAX_MEM=512m
+        volumes:
+            - ${LICENCE_KEY_PATH}:/opt/graviteeio-alert-engine/license/license.key:ro
+            - ./keystores/keystore-alert-engine-1.jks:/secure/keystore.jks:ro
+            - ./alert-engine_gravitee_1.yml:/opt/graviteeio-alert-engine/config/gravitee.yml:ro
+        networks:
+            - ae-1
 
-  alert-engine-1:
-    image: graviteeio/ae-engine:${AE_VERSION:-latest}
-    stop_grace_period: 5m
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://admin:adminadmin@localhost:18072/_node" ]
-      interval: 20s
-      timeout: 10s
-      retries: 3
-    deploy:
-      resources:
-        limits:
-          cpus: '1'
-          memory: 768M
-        reservations:
-          cpus: '1'
-          memory: 512M
-    environment:
-      - JAVA_OPTS=-Dlogging.level.com.graviteesource.ae.cluster.hz.channel.HazelcastChannelManager=DEBUG -Dlogging.level.com.graviteesource.ae.core.listener.EventListenerVerticle=DEBUG
-      - GIO_MIN_MEM=128m
-      - GIO_MAX_MEM=512m
-    volumes:
-      - ${LICENCE_KEY_PATH}:/opt/graviteeio-alert-engine/license/license.key:ro
-      - ./keystores/keystore-alert-engine-1.jks:/secure/keystore.jks:ro
-      - ./alert-engine_gravitee_1.yml:/opt/graviteeio-alert-engine/config/gravitee.yml:ro
-    networks:
-      - ae-1
-
-  alert-engine-2:
-    image: graviteeio/ae-engine:${AE_VERSION:-latest}
-    stop_grace_period: 5m
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://admin:adminadmin@localhost:18072/_node" ]
-      interval: 20s
-      timeout: 10s
-      retries: 3
-    deploy:
-      resources:
-        limits:
-          cpus: '1'
-          memory: 768M
-        reservations:
-          cpus: '1'
-          memory: 512M
-    environment:
-      - JAVA_OPTS=-Dlogging.level.com.graviteesource.ae.cluster.hz.channel.HazelcastChannelManager=DEBUG -Dlogging.level.com.graviteesource.ae.core.listener.EventListenerVerticle=DEBUG
-      - GIO_MIN_MEM=128m
-      - GIO_MAX_MEM=512m
-    volumes:
-      - ${LICENCE_KEY_PATH}:/opt/graviteeio-alert-engine/license/license.key:ro
-      - ./keystores/keystore-alert-engine-2.jks:/secure/keystore.jks:ro
-      - ./alert-engine_gravitee_2.yml:/opt/graviteeio-alert-engine/config/gravitee.yml:ro
-    networks:
-      - ae-2
+    alert-engine-2:
+        image: graviteeio/ae-engine:${AE_VERSION:-latest}
+        stop_grace_period: 5m
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://admin:adminadmin@localhost:18072/_node"]
+            interval: 20s
+            timeout: 10s
+            retries: 3
+        deploy:
+            resources:
+                limits:
+                    cpus: "1"
+                    memory: 768M
+                reservations:
+                    cpus: "1"
+                    memory: 512M
+        environment:
+            - JAVA_OPTS=-Dlogging.level.com.graviteesource.ae.cluster.hz.channel.HazelcastChannelManager=DEBUG -Dlogging.level.com.graviteesource.ae.core.listener.EventListenerVerticle=DEBUG
+            - GIO_MIN_MEM=128m
+            - GIO_MAX_MEM=512m
+        volumes:
+            - ${LICENCE_KEY_PATH}:/opt/graviteeio-alert-engine/license/license.key:ro
+            - ./keystores/keystore-alert-engine-2.jks:/secure/keystore.jks:ro
+            - ./alert-engine_gravitee_2.yml:/opt/graviteeio-alert-engine/config/gravitee.yml:ro
+        networks:
+            - ae-2

--- a/docker/integration-tests/one-apim_two-ae/gateway_gravitee_1.yml
+++ b/docker/integration-tests/one-apim_two-ae/gateway_gravitee_1.yml
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -92,12 +92,12 @@
 # For more information about MongoDB configuration, please have a look to:
 # - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html
 management:
-  type: mongodb                  # repository type
-  mongodb:                       # mongodb repository
-#    prefix:                      # collections prefix
-    dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
-    host: ${ds.mongodb.host}     # mongodb host (default localhost)
-    port: ${ds.mongodb.port}     # mongodb port (default 27017)
+    type: mongodb # repository type
+    mongodb: # mongodb repository
+        #    prefix:                      # collections prefix
+        dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
+        host: ${ds.mongodb.host} # mongodb host (default localhost)
+        port: ${ds.mongodb.port} # mongodb port (default 27017)
 
 ## Client settings
 #    description:                 # mongodb description (default gravitee.io)
@@ -167,67 +167,67 @@ management:
 # When defining rate-limiting policy, the gateway has to store data to share with other gateway instances.
 # In this example, we are using MongoDB to store counters.
 ratelimit:
-  type: mongodb
-  mongodb:
-    uri: mongodb://${ds.mongodb.host}:${ds.mongodb.port}/${ds.mongodb.dbname}
+    type: mongodb
+    mongodb:
+        uri: mongodb://${ds.mongodb.host}:${ds.mongodb.port}/${ds.mongodb.dbname}
 
 cache:
-  type: ehcache
+    type: ehcache
 
 # Reporters configuration (used to store reporting monitoring data, request metrics, healthchecks and others...
 # All reporters are enabled by default. To stop one of them, you have to add the property 'enabled: false'
 reporters:
-  # logging configuration
-#  logging:
-#    max_size: -1 # max size per API log content respectively : client-request, client-response, proxy-request and proxy-response in MB (-1 means no limit)
-#    excluded_response_types: video.*|audio.*|image.*|application\/octet-stream|application\/pdf # Response content types to exclude in logging (must be a regular expression)
-  # Elasticsearch reporter
-  elasticsearch:
-    enabled: true # Is the reporter enabled or not (default to true)
-    endpoints:
-      - http://${ds.elastic.host}:${ds.elastic.port}
-#    lifecycle:
-#      policy_property_name: index.lifecycle.name   #for openDistro, use 'opendistro.index_state_management.policy_id' instead of 'index.lifecycle.name'
-#      policies:
-#        monitor: my_policy ## ILM policy for the gravitee-monitor-* indexes
-#        request: my_policy ## ILM policy for the gravitee-request-* indexes
-#        health: my_policy ## ILM policy for the gravitee-health-* indexes
-#        log: my_policy ## ILM policy for the gravitee-log-* indexes
-#    index: gravitee
-#    index_per_type: true
-#    index_mode: daily         # "daily" indexes, suffixed with date. Or "ilm" managed indexes, without date
-#    bulk:
-#      actions: 1000           # Number of requests action before flush
-#      flush_interval: 5       # Flush interval in seconds
-#    settings:
-#      number_of_shards: 1
-#      number_of_replicas: 1
-#      refresh_interval: 5s
-#    pipeline:
-#      plugins:
-#        ingest: geoip, user_agent      # geoip and user_agent are enabled by default
-#    security:
-#      username: user
-#      password: secret
-#    http:
-#      timeout: 30000 # in milliseconds
-#      proxy:
-#        type: HTTP #HTTP, SOCK4, SOCK5
-#        http:
-#          host: localhost
-#          port: 3128
-#          username: user
-#          password: secret
-#        https:
-#          host: localhost
-#          port: 3128
-#          username: user
-#          password: secret
-#    template_mapping:
-#      path: ${gravitee.home}/config/reporter/elasticsearch/templates
-#      extended_request_mapping: request.ftl
-  file:
-    enabled: false # Is the reporter enabled or not (default to false)
+    # logging configuration
+    #  logging:
+    #    max_size: -1 # max size per API log content respectively : client-request, client-response, proxy-request and proxy-response in MB (-1 means no limit)
+    #    excluded_response_types: video.*|audio.*|image.*|application\/octet-stream|application\/pdf # Response content types to exclude in logging (must be a regular expression)
+    # Elasticsearch reporter
+    elasticsearch:
+        enabled: true # Is the reporter enabled or not (default to true)
+        endpoints:
+            - http://${ds.elastic.host}:${ds.elastic.port}
+    #    lifecycle:
+    #      policy_property_name: index.lifecycle.name   #for openDistro, use 'opendistro.index_state_management.policy_id' instead of 'index.lifecycle.name'
+    #      policies:
+    #        monitor: my_policy ## ILM policy for the gravitee-monitor-* indexes
+    #        request: my_policy ## ILM policy for the gravitee-request-* indexes
+    #        health: my_policy ## ILM policy for the gravitee-health-* indexes
+    #        log: my_policy ## ILM policy for the gravitee-log-* indexes
+    #    index: gravitee
+    #    index_per_type: true
+    #    index_mode: daily         # "daily" indexes, suffixed with date. Or "ilm" managed indexes, without date
+    #    bulk:
+    #      actions: 1000           # Number of requests action before flush
+    #      flush_interval: 5       # Flush interval in seconds
+    #    settings:
+    #      number_of_shards: 1
+    #      number_of_replicas: 1
+    #      refresh_interval: 5s
+    #    pipeline:
+    #      plugins:
+    #        ingest: geoip, user_agent      # geoip and user_agent are enabled by default
+    #    security:
+    #      username: user
+    #      password: secret
+    #    http:
+    #      timeout: 30000 # in milliseconds
+    #      proxy:
+    #        type: HTTP #HTTP, SOCK4, SOCK5
+    #        http:
+    #          host: localhost
+    #          port: 3128
+    #          username: user
+    #          password: secret
+    #        https:
+    #          host: localhost
+    #          port: 3128
+    #          username: user
+    #          password: secret
+    #    template_mapping:
+    #      path: ${gravitee.home}/config/reporter/elasticsearch/templates
+    #      extended_request_mapping: request.ftl
+    file:
+        enabled: false # Is the reporter enabled or not (default to false)
 #    fileName: ${gravitee.home}/metrics/%s-yyyy_mm_dd
 #    output: json # Can be csv, json, elasticsearch or message_pack
 #    request: # (Following mapping section is also available for other types: node, health-check, log)
@@ -244,82 +244,84 @@ reporters:
 # All services are enabled by default. To stop one of them, you have to add the property 'enabled: false' (See the
 # 'local' service for an example).
 services:
-  core:
-    http:
-      enabled: true
-      port: 18082
-      host: localhost
-      authentication:
-        # authentication type to be used for the core services
-        # - none : to disable authentication
-        # - basic : to use basic authentication
-        # default is "basic"
-        type: basic
-        users:
-          admin: adminadmin
+    core:
+        http:
+            enabled: true
+            port: 18082
+            host: localhost
+            authentication:
+                # authentication type to be used for the core services
+                # - none : to disable authentication
+                # - basic : to use basic authentication
+                # default is "basic"
+                type: basic
+                users:
+                    admin: adminadmin
 
-  # The thresholds to determine if a probe is healthy or not
-#  health:
-#    threshold:
-#      cpu: # Default is 80%
-#      memory: # Default is 80%
+    # The thresholds to determine if a probe is healthy or not
+    #  health:
+    #    threshold:
+    #      cpu: # Default is 80%
+    #      memory: # Default is 80%
 
-  # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
-  # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API
-  # and management UI
-  sync:
-    # Synchronization is done each 5 seconds
-    delay: 5000
-    unit: MILLISECONDS
-    distributed: false # By enabling this mode, data synchronization process is distributed over clustered API gateways.
-    bulk_items: 100 # Defines the number of items to retrieve during synchronization (events, plans, api keys, ...).
+    # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
+    # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API
+    # and management UI
+    sync:
+        # Synchronization is done each 5 seconds
+        delay: 5000
+        unit: MILLISECONDS
+        distributed: false # By enabling this mode, data synchronization process is distributed over clustered API gateways.
+        bulk_items:
+            100 # Defines the number of items to retrieve during synchronization (events, plans, api keys, ...).
 
-     # [Alpha] Enable Kubernetes Synchronization
-     # This sync service requires to install Gravitee Kubernetes Operator
-#    kubernetes:
-#      enabled: false
 
-  # Local registry service.
-  # This registry is used to load API Definition with json format from the file system. By doing so, you do not need
-  # to configure your API using the web console or the rest API (but you need to know and understand the json descriptor
-  # format to make it work....)
-  local:
-    enabled: false
-    path: ${gravitee.home}/apis # The path to API descriptors
+            # [Alpha] Enable Kubernetes Synchronization
+            # This sync service requires to install Gravitee Kubernetes Operator
+    #    kubernetes:
+    #      enabled: false
 
-  # Gateway monitoring service.
-  # This service retrieves metrics like os / process / jvm metrics and send them to an underlying reporting service.
-  monitoring:
-    delay: 5000
-    unit: MILLISECONDS
-    distributed: false # By enabling this mode, data monitoring gathering process is distributed over clustered API gateways.
+    # Local registry service.
+    # This registry is used to load API Definition with json format from the file system. By doing so, you do not need
+    # to configure your API using the web console or the rest API (but you need to know and understand the json descriptor
+    # format to make it work....)
+    local:
+        enabled: false
+        path: ${gravitee.home}/apis # The path to API descriptors
 
-  # metrics service
-  metrics:
-    enabled: false
-# default: local, http_method, http_code
-#    labels:
-#      - local
-#      - remote
-#      - http_method
-#      - http_code
-#      - http_path
-    prometheus:
-      enabled: true
+    # Gateway monitoring service.
+    # This service retrieves metrics like os / process / jvm metrics and send them to an underlying reporting service.
+    monitoring:
+        delay: 5000
+        unit: MILLISECONDS
+        distributed: false # By enabling this mode, data monitoring gathering process is distributed over clustered API gateways.
 
-  # heartbeat
-#  heartbeat:
-#    enabled: true
-#    delay: 5000
-#    unit: MILLISECONDS
-#    storeSystemProperties: true
+    # metrics service
+    metrics:
+        enabled: false
+        # default: local, http_method, http_code
+        #    labels:
+        #      - local
+        #      - remote
+        #      - http_method
+        #      - http_code
+        #      - http_path
+        prometheus:
+            enabled: true
 
-  tracing:
-    enabled: false
-    type: jaeger
-    jaeger:
-      host: localhost
-      port: 14250
+    # heartbeat
+    #  heartbeat:
+    #    enabled: true
+    #    delay: 5000
+    #    unit: MILLISECONDS
+    #    storeSystemProperties: true
+
+    tracing:
+        enabled: false
+        type: jaeger
+        jaeger:
+            host: localhost
+            port: 14250
 #      ssl:
 #        enabled: false
 
@@ -342,13 +344,13 @@ services:
 
 # Referenced properties
 ds:
-  mongodb:
-    dbname: gravitee
-    host: localhost
-    port: 27017
-  elastic:
-    host: localhost
-    port: 9200
+    mongodb:
+        dbname: gravitee
+        host: localhost
+        port: 27017
+    elastic:
+        host: localhost
+        port: 9200
 
 #system:
 #  # Proxy configuration that can be used to proxy request to api endpoints (see endpoint http configuration -> Use system proxy).
@@ -381,43 +383,43 @@ ds:
 #    param: api-key
 
 #el:
-  # Allows to define which methods or classes are accessible to the Expression Language engine (/!\ caution, changing default whitelist may expose you to security issues).
-  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-expression-language/master/src/main/resources/whitelist).
+# Allows to define which methods or classes are accessible to the Expression Language engine (/!\ caution, changing default whitelist may expose you to security issues).
+# A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-expression-language/master/src/main/resources/whitelist).
 #  whitelist:
-    # Allows to define if the specified list of method or classes should be append to the default one or should replace it.
-    # We recommend you to always choose 'append' unless you absolutely know what you are doing.
+# Allows to define if the specified list of method or classes should be append to the default one or should replace it.
+# We recommend you to always choose 'append' unless you absolutely know what you are doing.
 #    mode: append
-    # Define the list of classes or methods to append (or set) to made accessible to the Expression Language.
-    # start with 'method' to allow a specific method (complete signature).
-    # start with 'class' to allow a complete class. All methods of the class will then be accessible.
+# Define the list of classes or methods to append (or set) to made accessible to the Expression Language.
+# start with 'method' to allow a specific method (complete signature).
+# start with 'class' to allow a complete class. All methods of the class will then be accessible.
 #    list:
-      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
-      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
-      # Ex: allow access to all methods of DateTimeFormatter class
-      # - class java.time.format.DateTimeFormatter
+# Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+# - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+# Ex: allow access to all methods of DateTimeFormatter class
+# - class java.time.format.DateTimeFormatter
 
 #groovy:
-  # Allows to define which methods, fields, constructors, annotations or classes are accessible to the Groovy Script (/!\ caution, changing default whitelist may expose you to security issues).
-  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-policy-groovy/master/src/main/resources/groovy-whitelist).
+# Allows to define which methods, fields, constructors, annotations or classes are accessible to the Groovy Script (/!\ caution, changing default whitelist may expose you to security issues).
+# A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-policy-groovy/master/src/main/resources/groovy-whitelist).
 #  whitelist:
-    # Allows to define if the specified list of methods, fields, constructors or classes should be append to the default one or should replace it.
-    # We recommend you to always choose 'append' unless you absolutely know what you are doing.
+# Allows to define if the specified list of methods, fields, constructors or classes should be append to the default one or should replace it.
+# We recommend you to always choose 'append' unless you absolutely know what you are doing.
 #    mode: append
-    # Define the list of classes, methods, constructors, fields or annotations to append (or set) to made accessible to the Groovy Script.
-    # start with 'method' to allow a specific method (complete signature).
-    # start with 'class' to allow a complete class. All methods, constructors and fields of the class will then be accessible.
-    # start with 'new' to allow a specific constructor (complete signature).
-    # start with 'field' to allow access to a specific field of a class.
-    # start with 'annotation' to allow use of a specific annotation.
+# Define the list of classes, methods, constructors, fields or annotations to append (or set) to made accessible to the Groovy Script.
+# start with 'method' to allow a specific method (complete signature).
+# start with 'class' to allow a complete class. All methods, constructors and fields of the class will then be accessible.
+# start with 'new' to allow a specific constructor (complete signature).
+# start with 'field' to allow access to a specific field of a class.
+# start with 'annotation' to allow use of a specific annotation.
 #    list:
-      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
-      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
-      # Ex: allow access to all methods, constructors and fields of DateTimeFormatter class
-      # - class java.time.format.DateTimeFormatter
-      # Ex: allow usage of field Integer.MAX_VALUE
-      # - field java.lang.Integer MAX_VALUE
-      # Ex: allow usage of @Override annotation
-      # - annotation java.lang.Override
+# Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+# - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+# Ex: allow access to all methods, constructors and fields of DateTimeFormatter class
+# - class java.time.format.DateTimeFormatter
+# Ex: allow usage of field Integer.MAX_VALUE
+# - field java.lang.Integer MAX_VALUE
+# Ex: allow usage of @Override annotation
+# - annotation java.lang.Override
 
 # If you want to create cluster of nodes, you can change the Hazelcast file to configure the Hz network
 # Clustering capabilities can be used for:
@@ -438,47 +440,47 @@ ds:
 #        capacity: 8200  #if null defaults to 4096
 
 api:
-  # Encrypt API properties using this secret
-  properties:
-    encryption:
-      secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6
-  # when an API is un-deployed (either because it has been stopped or because it has restarted due to a configuration
-  # change), this timeout will be the maximum time (in milliseconds) to wait for all pending requests to terminate
+    # Encrypt API properties using this secret
+    properties:
+        encryption:
+            secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6
+    # when an API is un-deployed (either because it has been stopped or because it has restarted due to a configuration
+    # change), this timeout will be the maximum time (in milliseconds) to wait for all pending requests to terminate
 #  pending_requests_timeout: 10000
 
 # Graceful shutdown.
 #gracefulShutdown:
-  # Default delay is 0 but it can be useful to set it to an adequate value depending on how much time the load balancer takes to stop routing traffic to a gateway instance which is shutting down.
-  # When SIGTERM is sent to the gateway, the shutdown process begin, each client will be explicitly asked for closing connection and the shutdown delay will be applied.
-  # The shutdown delay should allow enough time to client to close their current active connections and create new one. In the same time the load balancer should progressively stop routing traffic to the gateway.
-  # After the delay is expired, the gateway continue the shutdown process. Any pending request will have a chance to finish gracefully and the gateway will stop normally unless it takes too much time and a SIGKILL signal is sent to the gateway.
+# Default delay is 0 but it can be useful to set it to an adequate value depending on how much time the load balancer takes to stop routing traffic to a gateway instance which is shutting down.
+# When SIGTERM is sent to the gateway, the shutdown process begin, each client will be explicitly asked for closing connection and the shutdown delay will be applied.
+# The shutdown delay should allow enough time to client to close their current active connections and create new one. In the same time the load balancer should progressively stop routing traffic to the gateway.
+# After the delay is expired, the gateway continue the shutdown process. Any pending request will have a chance to finish gracefully and the gateway will stop normally unless it takes too much time and a SIGKILL signal is sent to the gateway.
 #  delay: 0
 #  unit: MILLISECONDS
 
 # Since v3.15.0, a new internal classloader used to load api policies is in place.
 # Setting it to true will switch back to the legacy mode used prior the v3.15.0.
 classloader:
-  legacy:
-    enabled: false
+    legacy:
+        enabled: false
 
 alerts:
-  alert-engine:
-    enabled: true
-    engines:
-      default:
-        endpoints:
-          - https://alert-engine-1:8072/
-        security:
-          username: admin
-          password: adminadmin
-        ssl:
-          keystore:
-            type: jks # Supports jks, pem, pkcs12
-            path: /secure/keystore.jks
-            password: unsecure
-          truststore:
-            type: jks # Supports jks, pem, pkcs12
-            path: /secure/keystore.jks
-            password: unsecure
-    ws:
-      sendEventsOnHttp: false
+    alert-engine:
+        enabled: true
+        engines:
+            default:
+                endpoints:
+                    - https://alert-engine-1:8072/
+                security:
+                    username: admin
+                    password: adminadmin
+                ssl:
+                    keystore:
+                        type: jks # Supports jks, pem, pkcs12
+                        path: /secure/keystore.jks
+                        password: unsecure
+                    truststore:
+                        type: jks # Supports jks, pem, pkcs12
+                        path: /secure/keystore.jks
+                        password: unsecure
+        ws:
+            sendEventsOnHttp: false

--- a/docker/integration-tests/one-apim_two-ae/gateway_gravitee_2.yml
+++ b/docker/integration-tests/one-apim_two-ae/gateway_gravitee_2.yml
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -92,12 +92,12 @@
 # For more information about MongoDB configuration, please have a look to:
 # - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html
 management:
-  type: mongodb                  # repository type
-  mongodb:                       # mongodb repository
-#    prefix:                      # collections prefix
-    dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
-    host: ${ds.mongodb.host}     # mongodb host (default localhost)
-    port: ${ds.mongodb.port}     # mongodb port (default 27017)
+    type: mongodb # repository type
+    mongodb: # mongodb repository
+        #    prefix:                      # collections prefix
+        dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
+        host: ${ds.mongodb.host} # mongodb host (default localhost)
+        port: ${ds.mongodb.port} # mongodb port (default 27017)
 
 ## Client settings
 #    description:                 # mongodb description (default gravitee.io)
@@ -167,67 +167,67 @@ management:
 # When defining rate-limiting policy, the gateway has to store data to share with other gateway instances.
 # In this example, we are using MongoDB to store counters.
 ratelimit:
-  type: mongodb
-  mongodb:
-    uri: mongodb://${ds.mongodb.host}:${ds.mongodb.port}/${ds.mongodb.dbname}
+    type: mongodb
+    mongodb:
+        uri: mongodb://${ds.mongodb.host}:${ds.mongodb.port}/${ds.mongodb.dbname}
 
 cache:
-  type: ehcache
+    type: ehcache
 
 # Reporters configuration (used to store reporting monitoring data, request metrics, healthchecks and others...
 # All reporters are enabled by default. To stop one of them, you have to add the property 'enabled: false'
 reporters:
-  # logging configuration
-#  logging:
-#    max_size: -1 # max size per API log content respectively : client-request, client-response, proxy-request and proxy-response in MB (-1 means no limit)
-#    excluded_response_types: video.*|audio.*|image.*|application\/octet-stream|application\/pdf # Response content types to exclude in logging (must be a regular expression)
-  # Elasticsearch reporter
-  elasticsearch:
-    enabled: true # Is the reporter enabled or not (default to true)
-    endpoints:
-      - http://${ds.elastic.host}:${ds.elastic.port}
-#    lifecycle:
-#      policy_property_name: index.lifecycle.name   #for openDistro, use 'opendistro.index_state_management.policy_id' instead of 'index.lifecycle.name'
-#      policies:
-#        monitor: my_policy ## ILM policy for the gravitee-monitor-* indexes
-#        request: my_policy ## ILM policy for the gravitee-request-* indexes
-#        health: my_policy ## ILM policy for the gravitee-health-* indexes
-#        log: my_policy ## ILM policy for the gravitee-log-* indexes
-#    index: gravitee
-#    index_per_type: true
-#    index_mode: daily         # "daily" indexes, suffixed with date. Or "ilm" managed indexes, without date
-#    bulk:
-#      actions: 1000           # Number of requests action before flush
-#      flush_interval: 5       # Flush interval in seconds
-#    settings:
-#      number_of_shards: 1
-#      number_of_replicas: 1
-#      refresh_interval: 5s
-#    pipeline:
-#      plugins:
-#        ingest: geoip, user_agent      # geoip and user_agent are enabled by default
-#    security:
-#      username: user
-#      password: secret
-#    http:
-#      timeout: 30000 # in milliseconds
-#      proxy:
-#        type: HTTP #HTTP, SOCK4, SOCK5
-#        http:
-#          host: localhost
-#          port: 3128
-#          username: user
-#          password: secret
-#        https:
-#          host: localhost
-#          port: 3128
-#          username: user
-#          password: secret
-#    template_mapping:
-#      path: ${gravitee.home}/config/reporter/elasticsearch/templates
-#      extended_request_mapping: request.ftl
-  file:
-    enabled: false # Is the reporter enabled or not (default to false)
+    # logging configuration
+    #  logging:
+    #    max_size: -1 # max size per API log content respectively : client-request, client-response, proxy-request and proxy-response in MB (-1 means no limit)
+    #    excluded_response_types: video.*|audio.*|image.*|application\/octet-stream|application\/pdf # Response content types to exclude in logging (must be a regular expression)
+    # Elasticsearch reporter
+    elasticsearch:
+        enabled: true # Is the reporter enabled or not (default to true)
+        endpoints:
+            - http://${ds.elastic.host}:${ds.elastic.port}
+    #    lifecycle:
+    #      policy_property_name: index.lifecycle.name   #for openDistro, use 'opendistro.index_state_management.policy_id' instead of 'index.lifecycle.name'
+    #      policies:
+    #        monitor: my_policy ## ILM policy for the gravitee-monitor-* indexes
+    #        request: my_policy ## ILM policy for the gravitee-request-* indexes
+    #        health: my_policy ## ILM policy for the gravitee-health-* indexes
+    #        log: my_policy ## ILM policy for the gravitee-log-* indexes
+    #    index: gravitee
+    #    index_per_type: true
+    #    index_mode: daily         # "daily" indexes, suffixed with date. Or "ilm" managed indexes, without date
+    #    bulk:
+    #      actions: 1000           # Number of requests action before flush
+    #      flush_interval: 5       # Flush interval in seconds
+    #    settings:
+    #      number_of_shards: 1
+    #      number_of_replicas: 1
+    #      refresh_interval: 5s
+    #    pipeline:
+    #      plugins:
+    #        ingest: geoip, user_agent      # geoip and user_agent are enabled by default
+    #    security:
+    #      username: user
+    #      password: secret
+    #    http:
+    #      timeout: 30000 # in milliseconds
+    #      proxy:
+    #        type: HTTP #HTTP, SOCK4, SOCK5
+    #        http:
+    #          host: localhost
+    #          port: 3128
+    #          username: user
+    #          password: secret
+    #        https:
+    #          host: localhost
+    #          port: 3128
+    #          username: user
+    #          password: secret
+    #    template_mapping:
+    #      path: ${gravitee.home}/config/reporter/elasticsearch/templates
+    #      extended_request_mapping: request.ftl
+    file:
+        enabled: false # Is the reporter enabled or not (default to false)
 #    fileName: ${gravitee.home}/metrics/%s-yyyy_mm_dd
 #    output: json # Can be csv, json, elasticsearch or message_pack
 #    request: # (Following mapping section is also available for other types: node, health-check, log)
@@ -244,82 +244,84 @@ reporters:
 # All services are enabled by default. To stop one of them, you have to add the property 'enabled: false' (See the
 # 'local' service for an example).
 services:
-  core:
-    http:
-      enabled: true
-      port: 18082
-      host: localhost
-      authentication:
-        # authentication type to be used for the core services
-        # - none : to disable authentication
-        # - basic : to use basic authentication
-        # default is "basic"
-        type: basic
-        users:
-          admin: adminadmin
+    core:
+        http:
+            enabled: true
+            port: 18082
+            host: localhost
+            authentication:
+                # authentication type to be used for the core services
+                # - none : to disable authentication
+                # - basic : to use basic authentication
+                # default is "basic"
+                type: basic
+                users:
+                    admin: adminadmin
 
-  # The thresholds to determine if a probe is healthy or not
-#  health:
-#    threshold:
-#      cpu: # Default is 80%
-#      memory: # Default is 80%
+    # The thresholds to determine if a probe is healthy or not
+    #  health:
+    #    threshold:
+    #      cpu: # Default is 80%
+    #      memory: # Default is 80%
 
-  # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
-  # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API
-  # and management UI
-  sync:
-    # Synchronization is done each 5 seconds
-    delay: 5000
-    unit: MILLISECONDS
-    distributed: false # By enabling this mode, data synchronization process is distributed over clustered API gateways.
-    bulk_items: 100 # Defines the number of items to retrieve during synchronization (events, plans, api keys, ...).
+    # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
+    # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API
+    # and management UI
+    sync:
+        # Synchronization is done each 5 seconds
+        delay: 5000
+        unit: MILLISECONDS
+        distributed: false # By enabling this mode, data synchronization process is distributed over clustered API gateways.
+        bulk_items:
+            100 # Defines the number of items to retrieve during synchronization (events, plans, api keys, ...).
 
-     # [Alpha] Enable Kubernetes Synchronization
-     # This sync service requires to install Gravitee Kubernetes Operator
-#    kubernetes:
-#      enabled: false
 
-  # Local registry service.
-  # This registry is used to load API Definition with json format from the file system. By doing so, you do not need
-  # to configure your API using the web console or the rest API (but you need to know and understand the json descriptor
-  # format to make it work....)
-  local:
-    enabled: false
-    path: ${gravitee.home}/apis # The path to API descriptors
+            # [Alpha] Enable Kubernetes Synchronization
+            # This sync service requires to install Gravitee Kubernetes Operator
+    #    kubernetes:
+    #      enabled: false
 
-  # Gateway monitoring service.
-  # This service retrieves metrics like os / process / jvm metrics and send them to an underlying reporting service.
-  monitoring:
-    delay: 5000
-    unit: MILLISECONDS
-    distributed: false # By enabling this mode, data monitoring gathering process is distributed over clustered API gateways.
+    # Local registry service.
+    # This registry is used to load API Definition with json format from the file system. By doing so, you do not need
+    # to configure your API using the web console or the rest API (but you need to know and understand the json descriptor
+    # format to make it work....)
+    local:
+        enabled: false
+        path: ${gravitee.home}/apis # The path to API descriptors
 
-  # metrics service
-  metrics:
-    enabled: false
-# default: local, http_method, http_code
-#    labels:
-#      - local
-#      - remote
-#      - http_method
-#      - http_code
-#      - http_path
-    prometheus:
-      enabled: true
+    # Gateway monitoring service.
+    # This service retrieves metrics like os / process / jvm metrics and send them to an underlying reporting service.
+    monitoring:
+        delay: 5000
+        unit: MILLISECONDS
+        distributed: false # By enabling this mode, data monitoring gathering process is distributed over clustered API gateways.
 
-  # heartbeat
-#  heartbeat:
-#    enabled: true
-#    delay: 5000
-#    unit: MILLISECONDS
-#    storeSystemProperties: true
+    # metrics service
+    metrics:
+        enabled: false
+        # default: local, http_method, http_code
+        #    labels:
+        #      - local
+        #      - remote
+        #      - http_method
+        #      - http_code
+        #      - http_path
+        prometheus:
+            enabled: true
 
-  tracing:
-    enabled: false
-    type: jaeger
-    jaeger:
-      host: localhost
-      port: 14250
+    # heartbeat
+    #  heartbeat:
+    #    enabled: true
+    #    delay: 5000
+    #    unit: MILLISECONDS
+    #    storeSystemProperties: true
+
+    tracing:
+        enabled: false
+        type: jaeger
+        jaeger:
+            host: localhost
+            port: 14250
 #      ssl:
 #        enabled: false
 
@@ -342,13 +344,13 @@ services:
 
 # Referenced properties
 ds:
-  mongodb:
-    dbname: gravitee
-    host: localhost
-    port: 27017
-  elastic:
-    host: localhost
-    port: 9200
+    mongodb:
+        dbname: gravitee
+        host: localhost
+        port: 27017
+    elastic:
+        host: localhost
+        port: 9200
 
 #system:
 #  # Proxy configuration that can be used to proxy request to api endpoints (see endpoint http configuration -> Use system proxy).
@@ -381,43 +383,43 @@ ds:
 #    param: api-key
 
 #el:
-  # Allows to define which methods or classes are accessible to the Expression Language engine (/!\ caution, changing default whitelist may expose you to security issues).
-  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-expression-language/master/src/main/resources/whitelist).
+# Allows to define which methods or classes are accessible to the Expression Language engine (/!\ caution, changing default whitelist may expose you to security issues).
+# A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-expression-language/master/src/main/resources/whitelist).
 #  whitelist:
-    # Allows to define if the specified list of method or classes should be append to the default one or should replace it.
-    # We recommend you to always choose 'append' unless you absolutely know what you are doing.
+# Allows to define if the specified list of method or classes should be append to the default one or should replace it.
+# We recommend you to always choose 'append' unless you absolutely know what you are doing.
 #    mode: append
-    # Define the list of classes or methods to append (or set) to made accessible to the Expression Language.
-    # start with 'method' to allow a specific method (complete signature).
-    # start with 'class' to allow a complete class. All methods of the class will then be accessible.
+# Define the list of classes or methods to append (or set) to made accessible to the Expression Language.
+# start with 'method' to allow a specific method (complete signature).
+# start with 'class' to allow a complete class. All methods of the class will then be accessible.
 #    list:
-      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
-      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
-      # Ex: allow access to all methods of DateTimeFormatter class
-      # - class java.time.format.DateTimeFormatter
+# Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+# - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+# Ex: allow access to all methods of DateTimeFormatter class
+# - class java.time.format.DateTimeFormatter
 
 #groovy:
-  # Allows to define which methods, fields, constructors, annotations or classes are accessible to the Groovy Script (/!\ caution, changing default whitelist may expose you to security issues).
-  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-policy-groovy/master/src/main/resources/groovy-whitelist).
+# Allows to define which methods, fields, constructors, annotations or classes are accessible to the Groovy Script (/!\ caution, changing default whitelist may expose you to security issues).
+# A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-policy-groovy/master/src/main/resources/groovy-whitelist).
 #  whitelist:
-    # Allows to define if the specified list of methods, fields, constructors or classes should be append to the default one or should replace it.
-    # We recommend you to always choose 'append' unless you absolutely know what you are doing.
+# Allows to define if the specified list of methods, fields, constructors or classes should be append to the default one or should replace it.
+# We recommend you to always choose 'append' unless you absolutely know what you are doing.
 #    mode: append
-    # Define the list of classes, methods, constructors, fields or annotations to append (or set) to made accessible to the Groovy Script.
-    # start with 'method' to allow a specific method (complete signature).
-    # start with 'class' to allow a complete class. All methods, constructors and fields of the class will then be accessible.
-    # start with 'new' to allow a specific constructor (complete signature).
-    # start with 'field' to allow access to a specific field of a class.
-    # start with 'annotation' to allow use of a specific annotation.
+# Define the list of classes, methods, constructors, fields or annotations to append (or set) to made accessible to the Groovy Script.
+# start with 'method' to allow a specific method (complete signature).
+# start with 'class' to allow a complete class. All methods, constructors and fields of the class will then be accessible.
+# start with 'new' to allow a specific constructor (complete signature).
+# start with 'field' to allow access to a specific field of a class.
+# start with 'annotation' to allow use of a specific annotation.
 #    list:
-      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
-      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
-      # Ex: allow access to all methods, constructors and fields of DateTimeFormatter class
-      # - class java.time.format.DateTimeFormatter
-      # Ex: allow usage of field Integer.MAX_VALUE
-      # - field java.lang.Integer MAX_VALUE
-      # Ex: allow usage of @Override annotation
-      # - annotation java.lang.Override
+# Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+# - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+# Ex: allow access to all methods, constructors and fields of DateTimeFormatter class
+# - class java.time.format.DateTimeFormatter
+# Ex: allow usage of field Integer.MAX_VALUE
+# - field java.lang.Integer MAX_VALUE
+# Ex: allow usage of @Override annotation
+# - annotation java.lang.Override
 
 # If you want to create cluster of nodes, you can change the Hazelcast file to configure the Hz network
 # Clustering capabilities can be used for:
@@ -438,47 +440,47 @@ ds:
 #        capacity: 8200  #if null defaults to 4096
 
 api:
-  # Encrypt API properties using this secret
-  properties:
-    encryption:
-      secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6
-  # when an API is un-deployed (either because it has been stopped or because it has restarted due to a configuration
-  # change), this timeout will be the maximum time (in milliseconds) to wait for all pending requests to terminate
+    # Encrypt API properties using this secret
+    properties:
+        encryption:
+            secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6
+    # when an API is un-deployed (either because it has been stopped or because it has restarted due to a configuration
+    # change), this timeout will be the maximum time (in milliseconds) to wait for all pending requests to terminate
 #  pending_requests_timeout: 10000
 
 # Graceful shutdown.
 #gracefulShutdown:
-  # Default delay is 0 but it can be useful to set it to an adequate value depending on how much time the load balancer takes to stop routing traffic to a gateway instance which is shutting down.
-  # When SIGTERM is sent to the gateway, the shutdown process begin, each client will be explicitly asked for closing connection and the shutdown delay will be applied.
-  # The shutdown delay should allow enough time to client to close their current active connections and create new one. In the same time the load balancer should progressively stop routing traffic to the gateway.
-  # After the delay is expired, the gateway continue the shutdown process. Any pending request will have a chance to finish gracefully and the gateway will stop normally unless it takes too much time and a SIGKILL signal is sent to the gateway.
+# Default delay is 0 but it can be useful to set it to an adequate value depending on how much time the load balancer takes to stop routing traffic to a gateway instance which is shutting down.
+# When SIGTERM is sent to the gateway, the shutdown process begin, each client will be explicitly asked for closing connection and the shutdown delay will be applied.
+# The shutdown delay should allow enough time to client to close their current active connections and create new one. In the same time the load balancer should progressively stop routing traffic to the gateway.
+# After the delay is expired, the gateway continue the shutdown process. Any pending request will have a chance to finish gracefully and the gateway will stop normally unless it takes too much time and a SIGKILL signal is sent to the gateway.
 #  delay: 0
 #  unit: MILLISECONDS
 
 # Since v3.15.0, a new internal classloader used to load api policies is in place.
 # Setting it to true will switch back to the legacy mode used prior the v3.15.0.
 classloader:
-  legacy:
-    enabled: false
+    legacy:
+        enabled: false
 
 alerts:
-  alert-engine:
-    enabled: true
-    engines:
-      default:
-        endpoints:
-          - https://alert-engine-2:8072/
-        security:
-          username: admin
-          password: adminadmin
-        ssl:
-          keystore:
-            type: jks # Supports jks, pem, pkcs12
-            path: /secure/keystore.jks
-            password: unsecure
-          truststore:
-            type: jks # Supports jks, pem, pkcs12
-            path: /secure/keystore.jks
-            password: unsecure
-    ws:
-      sendEventsOnHttp: true
+    alert-engine:
+        enabled: true
+        engines:
+            default:
+                endpoints:
+                    - https://alert-engine-2:8072/
+                security:
+                    username: admin
+                    password: adminadmin
+                ssl:
+                    keystore:
+                        type: jks # Supports jks, pem, pkcs12
+                        path: /secure/keystore.jks
+                        password: unsecure
+                    truststore:
+                        type: jks # Supports jks, pem, pkcs12
+                        path: /secure/keystore.jks
+                        password: unsecure
+        ws:
+            sendEventsOnHttp: true

--- a/docker/integration-tests/one-apim_two-ae/generate-keystores.sh
+++ b/docker/integration-tests/one-apim_two-ae/generate-keystores.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/docker/integration-tests/one-apim_two-ae/management-api_gravitee.yml
+++ b/docker/integration-tests/one-apim_two-ae/management-api_gravitee.yml
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -77,47 +77,47 @@
 #      password: secret
 
 http:
-  api:
-    # Configure the listening path for the API. Default to /
-#    entrypoint: /
+    api:
+        # Configure the listening path for the API. Default to /
+    #    entrypoint: /
     # Configure Management API and Portal API.
-#    management:
-#      enabled: true
-#      entrypoint: ${http.api.entrypoint}management
-#      cors:
-# Allows to configure the header Access-Control-Allow-Origin (default value: *)
-# '*' is a valid value but is considered as a security risk as it will be opened to cross origin requests from anywhere.
-#        allow-origin: '*'
-# Allows to define how long the result of the preflight request should be cached for (default value; 1728000 [20 days])
-#        max-age: 1728000
-# Which methods to allow (default value: OPTIONS, GET, POST, PUT, DELETE)
-#        allow-methods: 'OPTIONS, GET, POST, PUT, DELETE'
-# Which headers to allow (default values: Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, X-Xsrf-Token)
-#        allow-headers: 'Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, X-Xsrf-Token'
-#  Allows to configure the header Access-Control-Expose-Headers
-#        exposed-headers: 'ETag;X-Xsrf-Token'
-#    portal:
-#      enabled: true
-#      entrypoint: ${http.api.entrypoint}portal
-#      cors:
-# Allows to configure the header Access-Control-Allow-Origin (default value: *)
-# '*' is a valid value but is considered as a security risk as it will be opened to cross origin requests from anywhere.
-#        allow-origin: '*'
-# Allows to define how long the result of the preflight request should be cached for (default value; 1728000 [20 days])
-#        max-age: 1728000
-# Which methods to allow (default value: OPTIONS, GET, POST, PUT, DELETE)
-#        allow-methods: 'OPTIONS, GET, POST, PUT, DELETE'
-# Which headers to allow (default values: Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, X-Xsrf-Token)
-#        allow-headers: 'Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, X-Xsrf-Token'
-#  Allows to configure the header Access-Control-Expose-Headers
-#        exposed-headers: 'ETag;X-Xsrf-Token'
-  csrf:
-    # Allows to enable or disable the CSRF protection. Enabled by default.
-    enabled: true
-  hsts:
-    enabled: true
-    include-sub-domains: true
-    max-age: 31536000
+    #    management:
+    #      enabled: true
+    #      entrypoint: ${http.api.entrypoint}management
+    #      cors:
+    # Allows to configure the header Access-Control-Allow-Origin (default value: *)
+    # '*' is a valid value but is considered as a security risk as it will be opened to cross origin requests from anywhere.
+    #        allow-origin: '*'
+    # Allows to define how long the result of the preflight request should be cached for (default value; 1728000 [20 days])
+    #        max-age: 1728000
+    # Which methods to allow (default value: OPTIONS, GET, POST, PUT, DELETE)
+    #        allow-methods: 'OPTIONS, GET, POST, PUT, DELETE'
+    # Which headers to allow (default values: Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, X-Xsrf-Token)
+    #        allow-headers: 'Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, X-Xsrf-Token'
+    #  Allows to configure the header Access-Control-Expose-Headers
+    #        exposed-headers: 'ETag;X-Xsrf-Token'
+    #    portal:
+    #      enabled: true
+    #      entrypoint: ${http.api.entrypoint}portal
+    #      cors:
+    # Allows to configure the header Access-Control-Allow-Origin (default value: *)
+    # '*' is a valid value but is considered as a security risk as it will be opened to cross origin requests from anywhere.
+    #        allow-origin: '*'
+    # Allows to define how long the result of the preflight request should be cached for (default value; 1728000 [20 days])
+    #        max-age: 1728000
+    # Which methods to allow (default value: OPTIONS, GET, POST, PUT, DELETE)
+    #        allow-methods: 'OPTIONS, GET, POST, PUT, DELETE'
+    # Which headers to allow (default values: Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, X-Xsrf-Token)
+    #        allow-headers: 'Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, X-Xsrf-Token'
+    #  Allows to configure the header Access-Control-Expose-Headers
+    #        exposed-headers: 'ETag;X-Xsrf-Token'
+    csrf:
+        # Allows to enable or disable the CSRF protection. Enabled by default.
+        enabled: true
+    hsts:
+        enabled: true
+        include-sub-domains: true
+        max-age: 31536000
 
 # Plugins repository
 #plugins:
@@ -132,12 +132,12 @@ http:
 # For more information about MongoDB configuration, please have a look to:
 # - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html
 management:
-  type: mongodb                  # repository type
-  mongodb:                       # mongodb repository
-#    prefix:                      # collections prefix
-    dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
-    host: ${ds.mongodb.host}     # mongodb host (default localhost)
-    port: ${ds.mongodb.port}     # mongodb port (default 27017)
+    type: mongodb # repository type
+    mongodb: # mongodb repository
+        #    prefix:                      # collections prefix
+        dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
+        host: ${ds.mongodb.host} # mongodb host (default localhost)
+        port: ${ds.mongodb.port} # mongodb port (default 27017)
 
 ## Client settings
 #    description:                 # mongodb description (default gravitee.io)
@@ -206,49 +206,48 @@ management:
 #    socketTimeout: 250
 
 services:
-  core:
-    http:
-      enabled: true
-      port: 18083
-      host: localhost
-      authentication:
-        # authentication type to be used for the core services
-        # - none : to disable authentication
-        # - basic : to use basic authentication
-        # default is "basic"
-        type: basic
-        users:
-          admin: adminadmin
+    core:
+        http:
+            enabled: true
+            port: 18083
+            host: localhost
+            authentication:
+                # authentication type to be used for the core services
+                # - none : to disable authentication
+                # - basic : to use basic authentication
+                # default is "basic"
+                type: basic
+                users:
+                    admin: adminadmin
 
-  # metrics service
-  metrics:
-    enabled: false
-    prometheus:
-      enabled: true
+    # metrics service
+    metrics:
+        enabled: false
+        prometheus:
+            enabled: true
 
-  # v3 upgrader service. Can be disabled after first launch.
-  v3-upgrader:
-    enabled: true
-  # AutoFetch service. (since 3.2)
-  # Use to fetch periodically documentation pages.
-  auto_fetch:
-    enabled: true
-    cron: "0 */5 * * * *"
+    # v3 upgrader service. Can be disabled after first launch.
+    v3-upgrader:
+        enabled: true
+    # AutoFetch service. (since 3.2)
+    # Use to fetch periodically documentation pages.
+    auto_fetch:
+        enabled: true
+        cron: "0 */5 * * * *"
 
-  # Subscription service
-  subscription:
-    enabled: true
-    #  Pre-expiration notification, number of days before the expiration an email should be send to subscriber and primary owner
-    pre-expiration-notification-schedule: 90,45,30
-
+    # Subscription service
+    subscription:
+        enabled: true
+        #  Pre-expiration notification, number of days before the expiration an email should be send to subscriber and primary owner
+        pre-expiration-notification-schedule: 90,45,30
 
 # Analytics repository is used to store all reporting, metrics, health-checks stored by gateway instances
 # This is the default configuration using Elasticsearch
 analytics:
-  type: elasticsearch
-  elasticsearch:
-    endpoints:
-      - http://${ds.elastic.host}:${ds.elastic.port}
+    type: elasticsearch
+    elasticsearch:
+        endpoints:
+            - http://${ds.elastic.host}:${ds.elastic.port}
 #    index: gravitee
 #    index_per_type: true
 #    index_mode: daily    # "daily" indexes, suffixed with date. Or "ilm" managed indexes, without date
@@ -281,60 +280,60 @@ analytics:
 #  API_CONSUMER: Can create and manage Applications
 #  ADMIN: Can manage global system
 security:
-  # When using an authentication providers, use trustAll mode for TLS connections
-  # trustAll: false
-  providers:  # authentication providers
-    - type: memory
-      # allow search results to display the user email. Be careful, It may be contrary to the user privacy.
+    # When using an authentication providers, use trustAll mode for TLS connections
+    # trustAll: false
+    providers: # authentication providers
+        - type: memory
+          # allow search results to display the user email. Be careful, It may be contrary to the user privacy.
+          #      allow-email-in-search-results: true
+          # password encoding/hashing algorithm. One of:
+          # - bcrypt : passwords are hashed with bcrypt (supports only $2a$ algorithm)
+          # - none : passwords are not hashed/encrypted
+          # default value is bcrypt
+          password-encoding-algo: bcrypt
+          users:
+              - user:
+                username: user
+                #firstname:
+                #lastname:
+                # Passwords are encoded using BCrypt
+                # Password value: password
+                password: $2a$10$9kjw/SH9gucCId3Lnt6EmuFreUAcXSZgpvAYuW2ISv7hSOhHRH1AO
+                roles: ORGANIZATION:USER,ENVIRONMENT:USER
+                # Useful to receive notifications
+                #email:
+              - user:
+                username: admin
+                #firstname:
+                #lastname:
+                # Password value: admin
+                password: $2a$10$Ihk05VSds5rUSgMdsMVi9OKMIx2yUvMz7y9VP3rJmQeizZLrhLMyq
+                roles: ORGANIZATION:ADMIN,ENVIRONMENT:ADMIN
+                #email:
+              - user:
+                username: api1
+                #firstname:
+                #lastname:
+                # Password value: api1
+                password: $2a$10$iXdXO4wAYdhx2LOwijsp7.PsoAZQ05zEdHxbriIYCbtyo.y32LTji
+                # You can declare multiple roles using comma separator
+                roles: ORGANIZATION:USER,ENVIRONMENT:API_PUBLISHER
+                #email:
+              - user:
+                username: application1
+                #firstname:
+                #lastname:
+                # Password value: application1
+                password: $2a$10$2gtKPYRB9zaVaPcn5RBx/.3T.7SeZoDGs9GKqbo9G64fKyXFR1He.
+                roles: ORGANIZATION:USER,ENVIRONMENT:USER
+                #email:
+        # Enable authentication using internal repository
+        - type: gravitee
+          # allow search results to display the user email. Be careful, It may be contrary to the user privacy.
 #      allow-email-in-search-results: true
-      # password encoding/hashing algorithm. One of:
-      # - bcrypt : passwords are hashed with bcrypt (supports only $2a$ algorithm)
-      # - none : passwords are not hashed/encrypted
-      # default value is bcrypt
-      password-encoding-algo: bcrypt
-      users:
-        - user:
-          username: user
-          #firstname:
-          #lastname:
-          # Passwords are encoded using BCrypt
-          # Password value: password
-          password: $2a$10$9kjw/SH9gucCId3Lnt6EmuFreUAcXSZgpvAYuW2ISv7hSOhHRH1AO
-          roles: ORGANIZATION:USER,ENVIRONMENT:USER
-          # Useful to receive notifications
-          #email:
-        - user:
-          username: admin
-          #firstname:
-          #lastname:
-          # Password value: admin
-          password: $2a$10$Ihk05VSds5rUSgMdsMVi9OKMIx2yUvMz7y9VP3rJmQeizZLrhLMyq
-          roles: ORGANIZATION:ADMIN,ENVIRONMENT:ADMIN
-          #email:
-        - user:
-          username: api1
-          #firstname:
-          #lastname:
-          # Password value: api1
-          password: $2a$10$iXdXO4wAYdhx2LOwijsp7.PsoAZQ05zEdHxbriIYCbtyo.y32LTji
-          # You can declare multiple roles using comma separator
-          roles: ORGANIZATION:USER,ENVIRONMENT:API_PUBLISHER
-          #email:
-        - user:
-          username: application1
-          #firstname:
-          #lastname:
-          # Password value: application1
-          password: $2a$10$2gtKPYRB9zaVaPcn5RBx/.3T.7SeZoDGs9GKqbo9G64fKyXFR1He.
-          roles: ORGANIZATION:USER,ENVIRONMENT:USER
-          #email:
-    # Enable authentication using internal repository
-    - type: gravitee
-      # allow search results to display the user email. Be careful, It may be contrary to the user privacy.
-#      allow-email-in-search-results: true
-    # Enable authentication using an LDAP/Active Directory
+# Enable authentication using an LDAP/Active Directory
 #    - type: ldap
-      # This is default LDAP configuration for ApacheDS
+# This is default LDAP configuration for ApacheDS
 #      context:
 #        username: "uid=admin,ou=system"
 #        password: "secret"
@@ -342,16 +341,16 @@ security:
 #        base: "c=io,o=gravitee" # the context source base
 #      authentication:
 #        user:
-          # Search base for user authentication. Defaults to "". Only used with user filter.
-          # It should be relative to the Base DN. If the whole DN is o=user accounts,c=io,o=gravitee then the base should be like this:
+# Search base for user authentication. Defaults to "". Only used with user filter.
+# It should be relative to the Base DN. If the whole DN is o=user accounts,c=io,o=gravitee then the base should be like this:
 #          base: "o=user accounts"
-          # The LDAP filter used to search for user during authentication. For example "(uid={0})". The substituted parameter is the user's login name.
+# The LDAP filter used to search for user during authentication. For example "(uid={0})". The substituted parameter is the user's login name.
 #          filter: "mail={0}"
-          # Specifies the attribute name which contains the user photo (URL or binary)
+# Specifies the attribute name which contains the user photo (URL or binary)
 #          photo-attribute: "jpegPhoto"
 #        group:
-          # Search base for groups searches. Defaults to "". Only used with group filter.
-          # It should be relative to the Base DN. If the whole DN is o=authorization groups,c=io,o=gravitee then the base should be like this:
+# Search base for groups searches. Defaults to "". Only used with group filter.
+# It should be relative to the Base DN. If the whole DN is o=authorization groups,c=io,o=gravitee then the base should be like this:
 #          base: "o=authorization groups"
 #          filter: "member={0}"
 #          role:
@@ -363,13 +362,13 @@ security:
 #              GRAVITEE-USERS: USER
 #            }
 #      lookup:
-         # allow search results to display the user email. Be careful, It may be contrary to the user privacy.
+# allow search results to display the user email. Be careful, It may be contrary to the user privacy.
 #         allow-email-in-search-results: true
 #        user:
-          # Search base for user searches. Defaults to "". Only used with user filter.
-          # It should be relative to the Base DN. If the whole DN is o=user accounts,c=io,o=gravitee then the base should be like this:
+# Search base for user searches. Defaults to "". Only used with user filter.
+# It should be relative to the Base DN. If the whole DN is o=user accounts,c=io,o=gravitee then the base should be like this:
 #          base: "o=user accounts"
-          # The LDAP filter used to search for user during authentication. For example "(uid={0})". The substituted parameter is the user's login name.
+# The LDAP filter used to search for user during authentication. For example "(uid={0})". The substituted parameter is the user's login name.
 #          filter: "(&(objectClass=Person)(|(cn=*{0}*)(uid={0})))"
 
 # Define absolute path for the a default API icon (png format)
@@ -379,11 +378,11 @@ security:
 
 # SMTP configuration used to send mails
 email:
-  enabled: false
-  host: smtp.my.domain
-  subject: "[Gravitee.io] %s"
-  port: 587
-  from: noreply@my.domain
+    enabled: false
+    host: smtp.my.domain
+    subject: "[Gravitee.io] %s"
+    port: 587
+    from: noreply@my.domain
 #  username: user@my.domain
 #  password: password
 #  properties:
@@ -398,89 +397,90 @@ email:
 #portal:
 #  themes:
 #    path: ${gravitee.home}/themes
-  # Allows domains to be used while generating some emails from the portal. ie. registration, forget password
-  # Empty whitelist means all urls are allowed.
+# Allows domains to be used while generating some emails from the portal. ie. registration, forget password
+# Empty whitelist means all urls are allowed.
 #  whitelist:
 #    - https://portal.domain.com
 #    - https://private-portal.domain.com
 
 # Referenced properties
 ds:
-  mongodb:
-    dbname: gravitee
-    host: localhost
-    port: 27017
-  elastic:
-    host: localhost
-    port: 9200
+    mongodb:
+        dbname: gravitee
+        host: localhost
+        port: 27017
+    elastic:
+        host: localhost
+        port: 9200
 
 jwt:
-  secret: myJWT4Gr4v1t33_S3cr3t
-  # Allows to define the end of validity of the token in seconds (default 604800 = a week)
-  #expire-after: 604800
-  # Allows to define the end of validity of the token in seconds for email registration (default 86400 = a day)
-  #email-registration-expire-after: 86400
-  # Allows to define issuer (default gravitee-management-auth)
-  #issuer: gravitee-management-auth
-  # Allows to define cookie context path (default /)
-  #cookie-path: /
-  # Allows to define cookie domain (default "")
-  #cookie-domain: .gravitee.io
-  # Allows to define if cookie secure only (default false)
-  #cookie-secure: true
+    secret: myJWT4Gr4v1t33_S3cr3t
+    # Allows to define the end of validity of the token in seconds (default 604800 = a week)
+    #expire-after: 604800
+    # Allows to define the end of validity of the token in seconds for email registration (default 86400 = a day)
+    #email-registration-expire-after: 86400
+    # Allows to define issuer (default gravitee-management-auth)
+    #issuer: gravitee-management-auth
+    # Allows to define cookie context path (default /)
+    #cookie-path: /
+    # Allows to define cookie domain (default "")
+    #cookie-domain: .gravitee.io
+    # Allows to define if cookie secure only (default false)
+    #cookie-secure: true
 
 swagger:
-  # Default scheme used when creating an API from a Swagger descriptor if there is no scheme specified.
-  scheme: https
+    # Default scheme used when creating an API from a Swagger descriptor if there is no scheme specified.
+    scheme: https
 
 # User management configuration
 user:
-  login:
-    # Create a default application when user connects to the portal for the very first time (default true)
-    #defaultApplication: true
+    login:
+        # Create a default application when user connects to the portal for the very first time (default true)
+        #defaultApplication: true
 
-  # Password complexity validation policy
-  # Applications should enforce password complexity rules to discourage easy to guess passwords.
-  # Passwords should require a minimum level of complexity that makes sense for the application and its user population.
-  password:
-    policy:
-      # Regex pattern for password validation (default to OWASP recommendations).
-      # 8 to 32 characters, no more than 2 consecutive equal characters, min 1 special characters (@ & # ...), min 1 upper case character.
-      pattern: ^(?:(?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))(?!.*(.)\1{2,})[A-Za-z0-9!~<>,;:_\-=?*+#."'&§`£€%°()\\\|\[\]\-\$\^\@\/]{8,32}$
-              # Example : ^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=])(?=\S+$).{8,}$
-              # ^                # start-of-string
-              #(?=.*[0-9])       # a digit must occur at least once
-              #(?=.*[a-z])       # a lower case letter must occur at least once
-              #(?=.*[A-Z])       # an upper case letter must occur at least once
-              #(?=.*[@#$%^&+=])  # a special character must occur at least once
-              #(?=\S+$)          # no whitespace allowed in the entire string
-              #.{8,}             # anything, at least eight places though
-              #$                 # end-of-string
-  creation:
-    token:
-      #expire-after: 86400
-  reference:
-      # Secret key used to generate reference of a user which is unique (default: s3cR3t4grAv1t33.1Ous3D4R3f3r3nc3)
-      # Must contains 32 chars (256 bits)
-      #secret:
-  anonymize-on-delete:
-    #enabled: false
+    # Password complexity validation policy
+    # Applications should enforce password complexity rules to discourage easy to guess passwords.
+    # Passwords should require a minimum level of complexity that makes sense for the application and its user population.
+    password:
+        policy:
+            # Regex pattern for password validation (default to OWASP recommendations).
+            # 8 to 32 characters, no more than 2 consecutive equal characters, min 1 special characters (@ & # ...), min 1 upper case character.
+            pattern:
+                ^(?:(?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))(?!.*(.)\1{2,})[A-Za-z0-9!~<>,;:_\-=?*+#."'&§`£€%°()\\\|\[\]\-\$\^\@\/]{8,32}$
+                # Example : ^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=])(?=\S+$).{8,}$
+                # ^                # start-of-string
+                #(?=.*[0-9])       # a digit must occur at least once
+                #(?=.*[a-z])       # a lower case letter must occur at least once
+                #(?=.*[A-Z])       # an upper case letter must occur at least once
+                #(?=.*[@#$%^&+=])  # a special character must occur at least once
+                #(?=\S+$)          # no whitespace allowed in the entire string
+                #.{8,}             # anything, at least eight places though
+                #$                 # end-of-string
+    creation:
+        token:
+            #expire-after: 86400
+    reference:
+        # Secret key used to generate reference of a user which is unique (default: s3cR3t4grAv1t33.1Ous3D4R3f3r3nc3)
+        # Must contains 32 chars (256 bits)
+        #secret:
+    anonymize-on-delete:
+        #enabled: false
 
 # Enable / disable documentation sanitize. Enabled by default.
 documentation:
-  markdown:
-    sanitize: true
+    markdown:
+        sanitize: true
 
 #imports:
-  # Enable / disable import from private hosts. Enabled by default. (See https://en.wikipedia.org/wiki/Private_network)
+# Enable / disable import from private hosts. Enabled by default. (See https://en.wikipedia.org/wiki/Private_network)
 #  allow-from-private: true
-  # Empty whitelist means all urls are allowed. Note: allow-from-private is ignored when whitelist is defined.
+# Empty whitelist means all urls are allowed. Note: allow-from-private is ignored when whitelist is defined.
 #  whitelist:
 #      - https://whitelist.domain1.com
 #      - https://restricted.domain2.com/whitelisted/path
 
 search:
-  data: ${gravitee.home}/data
+    data: ${gravitee.home}/data
 
 # global configuration of the http client
 #httpClient:
@@ -502,11 +502,11 @@ search:
 #      password: secret
 
 notifiers:
-  email:
-    enabled: true
-    host: ${email.host}
-    subject: ${email.subject}
-    port: ${email.port}
+    email:
+        enabled: true
+        host: ${email.host}
+        subject: ${email.subject}
+        port: ${email.port}
 #    username: ${email.username}
 #    password: ${email.password}
 #    starttls.enabled: false
@@ -520,7 +520,7 @@ notifiers:
 #      keyStorePassword:
 #  webhook:
 #    enabled: true
-    # Empty whitelist means all urls are allowed.
+# Empty whitelist means all urls are allowed.
 #    whitelist:
 #      - https://whitelist.domain1.com
 #      - https://restricted.domain2.com/whitelisted/path
@@ -534,43 +534,43 @@ notifiers:
 #  serviceUrl: https://www.google.com/recaptcha/api/siteverify
 
 #el:
-  # Allows to define which methods or classes are accessible to the Expression Language engine (/!\ caution, changing default whitelist may expose you to security issues).
-  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-expression-language/master/src/main/resources/whitelist).
+# Allows to define which methods or classes are accessible to the Expression Language engine (/!\ caution, changing default whitelist may expose you to security issues).
+# A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-expression-language/master/src/main/resources/whitelist).
 #  whitelist:
-    # Allows to define if the specified list of method or classes should be append to the default one or should replace it.
-    # We recommend you to always choose 'append' unless you absolutely kwnow what you are doing.
+# Allows to define if the specified list of method or classes should be append to the default one or should replace it.
+# We recommend you to always choose 'append' unless you absolutely kwnow what you are doing.
 #    mode: append
-    # Define the list of classes or methods to append (or set) to made accessible to the Expression Language.
-    # start with 'method' to allow a specific method (complete signature).
-    # start with 'class' to allow a complete class. All methods of the class will then be accessible.
+# Define the list of classes or methods to append (or set) to made accessible to the Expression Language.
+# start with 'method' to allow a specific method (complete signature).
+# start with 'class' to allow a complete class. All methods of the class will then be accessible.
 #    list:
-      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
-      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
-      # Ex: allow access to all methods of DateTimeFormatter class
-      # - class java.time.format.DateTimeFormatter
+# Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+# - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+# Ex: allow access to all methods of DateTimeFormatter class
+# - class java.time.format.DateTimeFormatter
 
 #groovy:
-  # Allows to define which methods, fields, constructors, annotations or classes are accessible to the Groovy Script (/!\ caution, changing default whitelist may expose you to security issues).
-  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-policy-groovy/master/src/main/resources/groovy-whitelist).
+# Allows to define which methods, fields, constructors, annotations or classes are accessible to the Groovy Script (/!\ caution, changing default whitelist may expose you to security issues).
+# A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-policy-groovy/master/src/main/resources/groovy-whitelist).
 #  whitelist:
-    # Allows to define if the specified list of methods, fields, constructors or classes should be append to the default one or should replace it.
-    # We recommend you to always choose 'append' unless you absolutely know what you are doing.
+# Allows to define if the specified list of methods, fields, constructors or classes should be append to the default one or should replace it.
+# We recommend you to always choose 'append' unless you absolutely know what you are doing.
 #    mode: append
-    # Define the list of classes, methods, constructors, fields or annotations to append (or set) to made accessible to the Groovy Script.
-    # start with 'method' to allow a specific method (complete signature).
-    # start with 'class' to allow a complete class. All methods, constructors and fields of the class will then be accessible.
-    # start with 'new' to allow a specific constructor (complete signature).
-    # start with 'field' to allow access to a specific field of a class.
-    # start with 'annotation' to allow use of a specific annotation.
+# Define the list of classes, methods, constructors, fields or annotations to append (or set) to made accessible to the Groovy Script.
+# start with 'method' to allow a specific method (complete signature).
+# start with 'class' to allow a complete class. All methods, constructors and fields of the class will then be accessible.
+# start with 'new' to allow a specific constructor (complete signature).
+# start with 'field' to allow access to a specific field of a class.
+# start with 'annotation' to allow use of a specific annotation.
 #    list:
-      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
-      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
-      # Ex: allow access to all methods, constructors and fields of DateTimeFormatter class
-      # - class java.time.format.DateTimeFormatter
-      # Ex: allow usage of field Integer.MAX_VALUE
-      # - field java.lang.Integer MAX_VALUE
-      # Ex: allow usage of @Override annotation
-      # - annotation java.lang.Override
+# Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+# - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+# Ex: allow access to all methods, constructors and fields of DateTimeFormatter class
+# - class java.time.format.DateTimeFormatter
+# Ex: allow usage of field Integer.MAX_VALUE
+# - field java.lang.Integer MAX_VALUE
+# Ex: allow usage of @Override annotation
+# - annotation java.lang.Override
 
 # Allows to enable or disable the 'Subscribe to newsletter' feature when user completes his profile on first log in. Default is enabled.
 #newsletter:
@@ -587,44 +587,44 @@ notifiers:
 #  url: https://cockpit.gravitee.io
 
 api:
-  # Encrypt API properties using this secret
-  properties:
-    encryption:
-      secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6
+    # Encrypt API properties using this secret
+    properties:
+        encryption:
+            secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6
 
 alerts:
-  alert-engine:
-    enabled: true
-    engines:
-      cluster1:
-        endpoints:
-          - https://alert-engine-2:8072/
-        security:
-          username: admin
-          password: adminadmin
-        ssl:
-          keystore:
-            type: jks # Supports jks, pem, pkcs12
-            path: /secure/keystore.jks
-            password: unsecure
-          truststore:
-            type: jks # Supports jks, pem, pkcs12
-            path: /secure/keystore.jks
-            password: unsecure
-      default:
-        endpoints:
-          - https://alert-engine-1:8072/
-        security:
-          username: admin
-          password: adminadmin
-        ssl:
-          keystore:
-            type: jks # Supports jks, pem, pkcs12
-            path: /secure/keystore.jks
-            password: unsecure
-          truststore:
-            type: jks # Supports jks, pem, pkcs12
-            path: /secure/keystore.jks
-            password: unsecure
-    ws:
-      sendEventsOnHttp: false
+    alert-engine:
+        enabled: true
+        engines:
+            cluster1:
+                endpoints:
+                    - https://alert-engine-2:8072/
+                security:
+                    username: admin
+                    password: adminadmin
+                ssl:
+                    keystore:
+                        type: jks # Supports jks, pem, pkcs12
+                        path: /secure/keystore.jks
+                        password: unsecure
+                    truststore:
+                        type: jks # Supports jks, pem, pkcs12
+                        path: /secure/keystore.jks
+                        password: unsecure
+            default:
+                endpoints:
+                    - https://alert-engine-1:8072/
+                security:
+                    username: admin
+                    password: adminadmin
+                ssl:
+                    keystore:
+                        type: jks # Supports jks, pem, pkcs12
+                        path: /secure/keystore.jks
+                        password: unsecure
+                    truststore:
+                        type: jks # Supports jks, pem, pkcs12
+                        path: /secure/keystore.jks
+                        password: unsecure
+        ws:
+            sendEventsOnHttp: false

--- a/gravitee-alert-engine-connector-api/pom.xml
+++ b/gravitee-alert-engine-connector-api/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/AbstractCommand.java
+++ b/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/AbstractCommand.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/AlertNotificationCommand.java
+++ b/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/AlertNotificationCommand.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/Command.java
+++ b/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/Command.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/Handler.java
+++ b/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/Handler.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/NodeDiscoveryCommand.java
+++ b/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/NodeDiscoveryCommand.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/ResolvePropertyCommand.java
+++ b/gravitee-alert-engine-connector-api/src/main/java/io/gravitee/ae/connector/api/command/ResolvePropertyCommand.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-core/pom.xml
+++ b/gravitee-alert-engine-connector-core/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-core/src/main/java/io/gravitee/ae/connector/core/ContextBuilder.java
+++ b/gravitee-alert-engine-connector-core/src/main/java/io/gravitee/ae/connector/core/ContextBuilder.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-core/src/main/java/io/gravitee/ae/connector/core/probe/AlertProbe.java
+++ b/gravitee-alert-engine-connector-core/src/main/java/io/gravitee/ae/connector/core/probe/AlertProbe.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-core/src/main/java/io/gravitee/ae/connector/core/spring/CoreConnectorConfiguration.java
+++ b/gravitee-alert-engine-connector-core/src/main/java/io/gravitee/ae/connector/core/spring/CoreConnectorConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/pom.xml
+++ b/gravitee-alert-engine-connector-ws/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
+            <version>${javax.annotation-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -156,7 +156,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>3.1.6</version>
+            <version>${awaitability.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -176,7 +176,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.7.1</version>
                 <configuration>
                     <finalName>gravitee-ae-connectors-ws-${project.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>

--- a/gravitee-alert-engine-connector-ws/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-alert-engine-connector-ws/src/main/assembly/plugin-assembly.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/AbstractConnector.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/AbstractConnector.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/Endpoint.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/Endpoint.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/HttpConnector.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/HttpConnector.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WebSocketConnector.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WebSocketConnector.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsConnectorPlugin.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsConnectorPlugin.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsEventProducer.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsEventProducer.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsTriggerProvider.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsTriggerProvider.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/CommandHandler.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/CommandHandler.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/CommandHandlerManager.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/CommandHandlerManager.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/CommandHandlerManagerImpl.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/CommandHandlerManagerImpl.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/discovery/DynamicEndpoint.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/discovery/DynamicEndpoint.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/discovery/NodeDiscoveryCommandHandler.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/discovery/NodeDiscoveryCommandHandler.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/notification/AlertNotificationCommandHandler.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/notification/AlertNotificationCommandHandler.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,10 +46,11 @@ public class AlertNotificationCommandHandler implements CommandHandler<AlertNoti
                 new Consumer<TriggerProvider.OnCommandListener>() {
                     @Override
                     public void accept(TriggerProvider.OnCommandListener listener) {
-                        io.gravitee.alert.api.trigger.command.AlertNotificationCommand alert = new io.gravitee.alert.api.trigger.command.AlertNotificationCommand(
-                            command.getTrigger(),
-                            command.getTimestamp()
-                        );
+                        io.gravitee.alert.api.trigger.command.AlertNotificationCommand alert =
+                            new io.gravitee.alert.api.trigger.command.AlertNotificationCommand(
+                                command.getTrigger(),
+                                command.getTimestamp()
+                            );
 
                         alert.setMessage(command.getMessage());
 

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/resolver/ResolvePropertyCommandHandler.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/resolver/ResolvePropertyCommandHandler.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/spring/CommandConfiguration.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/spring/CommandConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/ConnectorConfiguration.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/ConnectorConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/Engine.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/Engine.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/EngineSecurity.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/EngineSecurity.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/EngineSsl.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/EngineSsl.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/listener/ListenerManager.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/listener/ListenerManager.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/listener/ListenerManagerImpl.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/listener/ListenerManagerImpl.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/spring/WsConnectorConfiguration.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/spring/WsConnectorConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.0</version>
+        <version>22.3.0</version>
     </parent>
 
     <groupId>io.gravitee.ae</groupId>
@@ -40,12 +40,17 @@
     </modules>
 
     <properties>
-        <gravitee-bom.version>4.0.0</gravitee-bom.version>
-        <gravitee-node.version>3.0.1</gravitee-node.version>
-        <gravitee-plugin.version>1.25.0</gravitee-plugin.version>
-        <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
-        <mockito.version>4.5.1</mockito.version>
-        <assertj.version>3.22.0</assertj.version>
+        <gravitee-bom.version>8.2.17</gravitee-bom.version>
+        <gravitee-node.version>7.0.7</gravitee-node.version>
+        <gravitee-plugin.version>4.7.0</gravitee-plugin.version>
+        <gravitee-alert-api.version>2.1.0</gravitee-alert-api.version>
+        <prettier-maven-plugin.prettierJavaVersion>2.1.0</prettier-maven-plugin.prettierJavaVersion>
+
+        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
+        <awaitability.version>4.3.0</awaitability.version>
+
+        <skip.validation>false</skip.validation>
+        <jdk.version>17</jdk.version>
     </properties>
 
     <dependencyManagement>
@@ -60,11 +65,6 @@
             </dependency>
 
             <!-- Gravitee.io -->
-            <dependency>
-                <groupId>io.gravitee.cockpit</groupId>
-                <artifactId>gravitee-cockpit-api</artifactId>
-                <version>${gravitee-cockpit-api.version}</version>
-            </dependency>
             <dependency>
                 <groupId>io.gravitee.alert</groupId>
                 <artifactId>gravitee-alert-api</artifactId>
@@ -83,26 +83,6 @@
                 <version>${gravitee-node.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <!-- Test dependencies -->
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-junit-jupiter</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>${assertj.version}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -155,34 +135,33 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.11.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M6</version>
+                <version>3.5.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
                 <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
+                    <prettierJavaVersion>${prettier-maven-plugin.prettierJavaVersion}</prettierJavaVersion>
+                    <skip>${skip.validation}</skip>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/CJ-2953

**Description**

This commit:
- Updates all dependencies and does all necessary to make the build pass
- Updates gravitee orb version
- Updates renovate configuration

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-upgrade-gravitee-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/ae/gravitee-alert-engine-connectors/2.2.0-upgrade-gravitee-dependencies-SNAPSHOT/gravitee-alert-engine-connectors-2.2.0-upgrade-gravitee-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
