### PR TITLE
feat: upgrade to Vert.x 5 (and update dependencies)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.12.1
+    gravitee: gravitee-io/gravitee@5.4.2
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/AbstractConnector.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/AbstractConnector.java
@@ -23,6 +23,7 @@ import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.WebSocketClient;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -40,6 +41,7 @@ public abstract class AbstractConnector<T> extends AbstractLifecycleComponent<T>
 
     private final Logger logger = LoggerFactory.getLogger(AbstractConnector.class);
     protected HttpClient httpClient;
+    protected WebSocketClient webSocketClient;
 
     @Autowired
     protected Vertx vertx;
@@ -62,6 +64,13 @@ public abstract class AbstractConnector<T> extends AbstractLifecycleComponent<T>
                 logger.warn(ise.getMessage());
             }
         }
+        if (webSocketClient != null) {
+            try {
+                webSocketClient.close();
+            } catch (IllegalStateException ise) {
+                logger.warn(ise.getMessage());
+            }
+        }
     }
 
     public abstract Future<Void> writeTextMessage(String text);
@@ -69,7 +78,13 @@ public abstract class AbstractConnector<T> extends AbstractLifecycleComponent<T>
     protected void initHttpClient(Engine engine) {
         Assert.notNull(engine, "Engine can not be null");
         Endpoint endpoint = engine.nextEndpoint();
-        httpClient = vertx.createHttpClient(engine.getHttpClientOptions(endpoint));
+        httpClient = vertx.createHttpClient(engine.getHttpClientOptions(endpoint), engine.getHttpPoolOptions());
+    }
+
+    protected void initWebSocketClient(Engine engine) {
+        Assert.notNull(engine, "Engine can not be null");
+        Endpoint endpoint = engine.nextEndpoint();
+        webSocketClient = vertx.createWebSocketClient(engine.getWebSocketClientOptions(endpoint));
     }
 
     protected MultiMap getDefaultHeaders(Engine engine) {
@@ -77,8 +92,10 @@ public abstract class AbstractConnector<T> extends AbstractLifecycleComponent<T>
 
         // Read configuration to authenticate calls to Elasticsearch (basic authentication only)
         if (engine.getSecurity().getUsername() != null) {
-            String basicAuthorizationHeader =
-                this.initEncodedAuthorization(engine.getSecurity().getUsername(), engine.getSecurity().getPassword());
+            String basicAuthorizationHeader = this.initEncodedAuthorization(
+                engine.getSecurity().getUsername(),
+                engine.getSecurity().getPassword()
+            );
             headers.set(HttpHeaders.AUTHORIZATION, basicAuthorizationHeader);
         }
 

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WebSocketConnector.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WebSocketConnector.java
@@ -24,6 +24,7 @@ import io.gravitee.alert.api.trigger.TriggerProvider;
 import io.gravitee.node.api.Node;
 import io.vertx.circuitbreaker.CircuitBreaker;
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
+import io.vertx.circuitbreaker.RetryPolicy;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
@@ -75,16 +76,15 @@ public class WebSocketConnector extends AbstractConnector<WebSocketConnector> {
         if (enabled) {
             logger.info("AlertEngine connector is enabled. Starting WS connector.");
 
-            circuitBreaker =
-                CircuitBreaker.create(
-                    "alert-engine-event-producer",
-                    vertx,
-                    new CircuitBreakerOptions().setMaxRetries(Integer.MAX_VALUE).setNotificationAddress(null)
-                );
+            circuitBreaker = CircuitBreaker.create(
+                "alert-engine-event-producer",
+                vertx,
+                new CircuitBreakerOptions().setMaxRetries(Integer.MAX_VALUE).setNotificationAddress(null)
+            );
 
             // Back-off retry
             // TODO use jitter
-            circuitBreaker.retryPolicy(integer -> 5000L);
+            circuitBreaker.retryPolicy(RetryPolicy.constantDelay(5000L));
 
             connect();
         } else {
@@ -111,58 +111,51 @@ public class WebSocketConnector extends AbstractConnector<WebSocketConnector> {
 
                     // Initialize ping-pong
                     // See RFC 6455 Section <a href="https://tools.ietf.org/html/rfc6455#section-5.5.2"
-                    pongHandlerId =
-                        vertx.setPeriodic(
-                            PING_HANDLER_DELAY,
-                            aLong -> webSocket.writePing(Buffer.buffer(node.id() + " - " + node.hostname()))
-                        );
+                    pongHandlerId = vertx.setPeriodic(PING_HANDLER_DELAY, aLong ->
+                        webSocket.writePing(Buffer.buffer(node.id() + " - " + node.hostname()))
+                    );
 
                     if (discovery) {
                         logger.info("Discovery mode is enabled, listening for alert engine instances...");
                     }
 
                     WebSocketConnector.this.webSocket.handler(buffer -> {
-                            final String sCommand = buffer.toString();
+                        final String sCommand = buffer.toString();
 
-                            try {
-                                Command command = DatabindCodec.mapper().readValue(sCommand, Command.class);
+                        try {
+                            Command command = DatabindCodec.mapper().readValue(sCommand, Command.class);
 
-                                commandHandlerManager.handle(
-                                    command,
-                                    result -> {
-                                        if (result != null) {
-                                            WebSocketConnector.this.webSocket.writeTextMessage(
-                                                    "reply:" + command.id() + ":" + Json.encode(result)
-                                                );
-                                        }
-                                    }
-                                );
-                            } catch (IOException ioe) {
-                                logger.error("Unexpected error while reading command: {}", sCommand, ioe);
-                            }
-                        });
+                            commandHandlerManager.handle(command, result -> {
+                                if (result != null) {
+                                    WebSocketConnector.this.webSocket.writeTextMessage("reply:" + command.id() + ":" + Json.encode(result));
+                                }
+                            });
+                        } catch (IOException ioe) {
+                            logger.error("Unexpected error while reading command: {}", sCommand, ioe);
+                        }
+                    });
 
                     WebSocketConnector.this.webSocket.exceptionHandler(throwable ->
-                            logger.error("An error occurred on the websocket connection", throwable)
-                        );
+                        logger.error("An error occurred on the websocket connection", throwable)
+                    );
 
                     WebSocketConnector.this.webSocket.pongHandler(data -> logger.debug("Get a pong from Alert Engine server"));
 
                     WebSocketConnector.this.webSocket.closeHandler(event1 -> {
-                            logger.debug("Connection to Alert Engine server has been closed.");
+                        logger.debug("Connection to Alert Engine server has been closed.");
 
-                            if (pongHandlerId != 0L) {
-                                vertx.cancelTimer(pongHandlerId);
-                            }
+                        if (pongHandlerId != 0L) {
+                            vertx.cancelTimer(pongHandlerId);
+                        }
 
-                            // Release reference to the websocket connection
-                            WebSocketConnector.this.webSocket = null;
+                        // Release reference to the websocket connection
+                        WebSocketConnector.this.webSocket = null;
 
-                            invokeOnDisconnectionListeners();
+                        invokeOnDisconnectionListeners();
 
-                            // How to force to reconnect ?
-                            connect();
-                        });
+                        // How to force to reconnect ?
+                        connect();
+                    });
 
                     invokeOnConnectionListeners();
                 } else {
@@ -186,7 +179,7 @@ public class WebSocketConnector extends AbstractConnector<WebSocketConnector> {
     }
 
     private void doConnect(Promise<WebSocket> webSocketPromise) {
-        initHttpClient(engine);
+        initWebSocketClient(engine);
         Endpoint endpoint = engine.currentEndpoint();
 
         if (endpoint != null) {
@@ -219,8 +212,8 @@ public class WebSocketConnector extends AbstractConnector<WebSocketConnector> {
                 }
             }
 
-            httpClient
-                .webSocket(webSocketConnectOptions)
+            webSocketClient
+                .connect(webSocketConnectOptions)
                 .onSuccess(ws -> {
                     // Re-init endpoint counter
                     engine.resetEndpointRetryCount(endpoint);
@@ -236,8 +229,8 @@ public class WebSocketConnector extends AbstractConnector<WebSocketConnector> {
                     );
                     webSocketPromise.fail(throwable);
 
-                    // Force the HTTP client to close after a defect
-                    httpClient.close();
+                    // Force the WebSocket client to close after a defect
+                    webSocketClient.close();
                 });
         }
     }

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsEventProducer.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsEventProducer.java
@@ -27,10 +27,10 @@ import io.reactivex.rxjava3.core.BackpressureStrategy;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.FlowableEmitter;
 import io.reactivex.rxjava3.schedulers.Schedulers;
-import io.vertx.core.impl.ConcurrentHashSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +75,7 @@ public class WsEventProducer extends AbstractEventProducer implements Applicatio
     private Context context;
 
     // Keep a copy of events while waiting for producer being started
-    private final Set<Event> pendingEvents = new ConcurrentHashSet<>();
+    private final Set<Event> pendingEvents = ConcurrentHashMap.newKeySet();
 
     private FlowableEmitter<Event> eventEmitter;
 
@@ -97,9 +97,9 @@ public class WsEventProducer extends AbstractEventProducer implements Applicatio
     protected void doStart() throws Exception {
         context = contextBuilder.build();
 
-        final Flowable<Event> bufferedEvents = Flowable
-            .create(this::prepareEventEmitter, BackpressureStrategy.LATEST)
-            .doOnNext(this::copyContextToEvent);
+        final Flowable<Event> bufferedEvents = Flowable.create(this::prepareEventEmitter, BackpressureStrategy.LATEST).doOnNext(
+            this::copyContextToEvent
+        );
 
         logger.info("AlertEngine connector is enabled. Starting connector.");
         Engine defaultEngine = configuration.getDefaultEngine(); // event producer only send the events to the default engine

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/discovery/NodeDiscoveryCommandHandler.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/discovery/NodeDiscoveryCommandHandler.java
@@ -60,7 +60,12 @@ public class NodeDiscoveryCommandHandler implements CommandHandler<NodeDiscovery
             if (DISCOVERY_NODE_CHANGED.equalsIgnoreCase(command.getAction())) {
                 // Endpoint must be registered only if target does not already exist
 
-                if (defaultEngine.getEndpoints().stream().noneMatch(edpt -> edpt.getUrl().equals(websocketEndpoint.getUrl()))) {
+                if (
+                    defaultEngine
+                        .getEndpoints()
+                        .stream()
+                        .noneMatch(edpt -> edpt.getUrl().equals(websocketEndpoint.getUrl()))
+                ) {
                     logger.info("An alert engine instance has been discovered at {}", websocketEndpoint.getUrl());
                     defaultEngine.getEndpoints().add(websocketEndpoint);
                 }

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/resolver/ResolvePropertyCommandHandler.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/command/resolver/ResolvePropertyCommandHandler.java
@@ -46,12 +46,9 @@ public class ResolvePropertyCommandHandler implements CommandHandler<ResolveProp
             .findFirst();
 
         optListener.ifPresent(listener ->
-            listener.doOnCommand(
-                new io.gravitee.alert.api.trigger.command.ResolvePropertyCommand(command.getProperties()),
-                result -> {
-                    resultHandler.handle(result);
-                }
-            )
+            listener.doOnCommand(new io.gravitee.alert.api.trigger.command.ResolvePropertyCommand(command.getProperties()), result -> {
+                resultHandler.handle(result);
+            })
         );
     }
 }

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/ConnectorConfiguration.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/ConnectorConfiguration.java
@@ -249,20 +249,19 @@ public class ConnectorConfiguration {
         Map<String, Engine> result = new HashMap<>();
 
         // try first with engines tag
-        final var engineNames =
-            ((AbstractEnvironment) environment).getPropertySources()
-                .stream()
-                .filter(propertySource -> propertySource instanceof EnumerablePropertySource)
-                .filter(propertySource -> propertySource.getSource() instanceof Map)
-                .flatMap(propertySource ->
-                    ((EnumerablePropertySource<Map<?, ?>>) propertySource).getSource().keySet().stream().map(String::valueOf)
-                )
-                .filter(key -> key.startsWith(keyInitial))
-                .map(key -> {
-                    String replace = key.replace(keyInitial, "");
-                    return replace.substring(0, replace.indexOf("."));
-                })
-                .collect(toSet());
+        final var engineNames = ((AbstractEnvironment) environment).getPropertySources()
+            .stream()
+            .filter(propertySource -> propertySource instanceof EnumerablePropertySource)
+            .filter(propertySource -> propertySource.getSource() instanceof Map)
+            .flatMap(propertySource ->
+                ((EnumerablePropertySource<Map<?, ?>>) propertySource).getSource().keySet().stream().map(String::valueOf)
+            )
+            .filter(key -> key.startsWith(keyInitial))
+            .map(key -> {
+                String replace = key.replace(keyInitial, "");
+                return replace.substring(0, replace.indexOf("."));
+            })
+            .collect(toSet());
 
         engineNames.forEach(name -> {
             String key = String.format("%s%s", keyInitial, name);
@@ -279,7 +278,8 @@ public class ConnectorConfiguration {
             if (result.get(DEFAULT_ENGINE_NAME) == null) {
                 throw new RuntimeException("Default engine is not found! You need to have a default engine in your configuration.");
             }
-        } else { // for backward compatibility
+        } else {
+            // for backward compatibility
             Engine defaultEngine = new Engine(
                 this,
                 initializeEndpoints("alerts.alert-engine.ws.endpoints").stream().map(Endpoint::new).collect(toList()),

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/Engine.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/Engine.java
@@ -17,6 +17,8 @@ package io.gravitee.ae.connector.ws.configuration;
 
 import io.gravitee.ae.connector.ws.Endpoint;
 import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.PoolOptions;
+import io.vertx.core.http.WebSocketClientOptions;
 import io.vertx.core.net.*;
 import java.net.URI;
 import java.util.HashMap;
@@ -61,38 +63,72 @@ public class Engine {
 
     public HttpClientOptions getHttpClientOptions(Endpoint endpoint) {
         URI target = URI.create(endpoint.getUrl());
-        final int port = target.getPort() != -1
-            ? target.getPort()
-            : (HTTPS_SCHEME.equals(target.getScheme()) ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT);
         HttpClientOptions httpClientOptions = new HttpClientOptions();
         httpClientOptions.setConnectTimeout(connectorConfiguration.getConnectTimeout());
-        httpClientOptions.setDefaultPort(port);
+        httpClientOptions.setDefaultPort(resolvePort(target));
         httpClientOptions.setDefaultHost(target.getHost());
-        httpClientOptions.setMaxPoolSize(connectorConfiguration.getMaxPoolSize());
         httpClientOptions.setIdleTimeout(connectorConfiguration.getIdleTimeout());
         httpClientOptions.setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
         httpClientOptions.setPipelining(connectorConfiguration.isPipelining());
         httpClientOptions.setKeepAlive(connectorConfiguration.isKeepAlive());
-        httpClientOptions.setTryUseCompression(connectorConfiguration.isTryCompression());
+        httpClientOptions.setDecompressionSupported(connectorConfiguration.isTryCompression());
 
-        if (HTTPS_SCHEME.equalsIgnoreCase(target.getScheme())) {
-            // Configure SSL
+        if (isHttps(target)) {
             httpClientOptions.setSsl(true);
             httpClientOptions.setTrustAll(sslConfig.isTrustAll());
             httpClientOptions.setVerifyHost(sslConfig.isHostnameVerifier());
-            setKeyStoreOptions(httpClientOptions);
-            setTruststoreOptions(httpClientOptions);
+            configureSslCertificates(httpClientOptions);
         }
 
         setProxyOptions(target, httpClientOptions);
         return httpClientOptions;
     }
 
-    private void setProxyOptions(URI target, HttpClientOptions httpClientOptions) {
+    public PoolOptions getHttpPoolOptions() {
+        return new PoolOptions().setHttp1MaxSize(connectorConfiguration.getMaxPoolSize());
+    }
+
+    public WebSocketClientOptions getWebSocketClientOptions(Endpoint endpoint) {
+        URI target = URI.create(endpoint.getUrl());
+        WebSocketClientOptions webSocketClientOptions = new WebSocketClientOptions();
+        webSocketClientOptions.setConnectTimeout(connectorConfiguration.getConnectTimeout());
+        webSocketClientOptions.setDefaultPort(resolvePort(target));
+        webSocketClientOptions.setDefaultHost(target.getHost());
+        webSocketClientOptions.setIdleTimeout(connectorConfiguration.getIdleTimeout());
+        webSocketClientOptions.setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+        webSocketClientOptions.setMaxConnections(connectorConfiguration.getMaxPoolSize());
+
+        if (isHttps(target)) {
+            webSocketClientOptions.setSsl(true);
+            webSocketClientOptions.setTrustAll(sslConfig.isTrustAll());
+            webSocketClientOptions.setVerifyHost(sslConfig.isHostnameVerifier());
+            configureSslCertificates(webSocketClientOptions);
+        }
+
+        setProxyOptions(target, webSocketClientOptions);
+        return webSocketClientOptions;
+    }
+
+    private int resolvePort(URI target) {
+        return target.getPort() != -1
+            ? target.getPort()
+            : (HTTPS_SCHEME.equals(target.getScheme()) ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT);
+    }
+
+    private boolean isHttps(URI target) {
+        return HTTPS_SCHEME.equalsIgnoreCase(target.getScheme());
+    }
+
+    private void configureSslCertificates(TCPSSLOptions options) {
+        setKeyStoreOptions(options);
+        setTruststoreOptions(options);
+    }
+
+    private void setProxyOptions(URI target, ClientOptionsBase clientOptions) {
         if (connectorConfiguration.isUseSystemProxy()) {
             ProxyOptions proxyOptions = new ProxyOptions().setType(ProxyType.valueOf(connectorConfiguration.getProxyType()));
             if (HTTPS_SCHEME.equals(target.getScheme())) {
-                httpClientOptions.setProxyOptions(
+                clientOptions.setProxyOptions(
                     proxyOptions
                         .setHost(connectorConfiguration.getProxyHttpsHost())
                         .setPort(connectorConfiguration.getProxyHttpsPort())
@@ -100,7 +136,7 @@ public class Engine {
                         .setPassword(connectorConfiguration.getProxyHttpsPassword())
                 );
             } else {
-                httpClientOptions.setProxyOptions(
+                clientOptions.setProxyOptions(
                     proxyOptions
                         .setHost(connectorConfiguration.getProxyHttpHost())
                         .setPort(connectorConfiguration.getProxyHttpPort())
@@ -111,21 +147,21 @@ public class Engine {
         }
     }
 
-    private void setTruststoreOptions(HttpClientOptions httpClientOptions) {
+    private void setTruststoreOptions(TCPSSLOptions tcpSslOptions) {
         if (sslConfig.getTruststoreType() != null) {
             switch (sslConfig.getTruststoreType().toUpperCase()) {
                 case KEYSTORE_FORMAT_JKS:
-                    httpClientOptions.setTrustStoreOptions(
+                    tcpSslOptions.setTrustOptions(
                         new JksOptions().setPath(sslConfig.getTruststorePath()).setPassword(sslConfig.getTruststorePassword())
                     );
                     break;
                 case KEYSTORE_FORMAT_PKCS12:
-                    httpClientOptions.setPfxTrustOptions(
+                    tcpSslOptions.setTrustOptions(
                         new PfxOptions().setPath(sslConfig.getTruststorePath()).setPassword(sslConfig.getTruststorePassword())
                     );
                     break;
                 case KEYSTORE_FORMAT_PEM:
-                    httpClientOptions.setPemTrustOptions(new PemTrustOptions().addCertPath(sslConfig.getTruststorePath()));
+                    tcpSslOptions.setTrustOptions(new PemTrustOptions().addCertPath(sslConfig.getTruststorePath()));
                     break;
                 default:
                     //Do nothing
@@ -134,21 +170,21 @@ public class Engine {
         }
     }
 
-    private void setKeyStoreOptions(HttpClientOptions httpClientOptions) {
+    private void setKeyStoreOptions(TCPSSLOptions tcpSslOptions) {
         if (sslConfig.getKeystoreType() != null) {
             switch (sslConfig.getKeystoreType().toUpperCase()) {
                 case KEYSTORE_FORMAT_JKS:
-                    httpClientOptions.setKeyStoreOptions(
+                    tcpSslOptions.setKeyCertOptions(
                         new JksOptions().setPath(sslConfig.getKeystorePath()).setPassword(sslConfig.getKeystorePassword())
                     );
                     break;
                 case KEYSTORE_FORMAT_PKCS12:
-                    httpClientOptions.setPfxKeyCertOptions(
+                    tcpSslOptions.setKeyCertOptions(
                         new PfxOptions().setPath(sslConfig.getKeystorePath()).setPassword(sslConfig.getKeystorePassword())
                     );
                     break;
                 case KEYSTORE_FORMAT_PEM:
-                    httpClientOptions.setPemKeyCertOptions(
+                    tcpSslOptions.setKeyCertOptions(
                         new PemKeyCertOptions().setCertPaths(sslConfig.getKeystorePemCerts()).setKeyPaths(sslConfig.getKeystorePemKeys())
                     );
                     break;

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.6.0</version>
+        <version>23.5.0</version>
     </parent>
 
     <groupId>io.gravitee.ae</groupId>
@@ -40,17 +40,15 @@
     </modules>
 
     <properties>
-        <gravitee-bom.version>8.2.17</gravitee-bom.version>
-        <gravitee-node.version>7.18.0</gravitee-node.version>
-        <gravitee-plugin.version>4.7.0</gravitee-plugin.version>
-        <gravitee-alert-api.version>2.1.18</gravitee-alert-api.version>
-        <prettier-maven-plugin.prettierJavaVersion>2.1.0</prettier-maven-plugin.prettierJavaVersion>
+        <gravitee-bom.version>9.0.0-beta.2</gravitee-bom.version>
+        <gravitee-node.version>8.0.0-beta.2</gravitee-node.version>
+        <gravitee-plugin.version>4.10.0</gravitee-plugin.version>
+        <gravitee-alert-api.version>2.1.22</gravitee-alert-api.version>
 
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <awaitability.version>4.3.0</awaitability.version>
 
         <skip.validation>false</skip.validation>
-        <jdk.version>17</jdk.version>
     </properties>
 
     <dependencyManagement>
@@ -130,48 +128,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.1</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.12.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.4</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.1</version>
-                <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <configuration>
-                    <prettierJavaVersion>${prettier-maven-plugin.prettierJavaVersion}</prettierJavaVersion>
-                    <skip>${skip.validation}</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
BREAKING CHANGE: upgrade to Vert.x 5

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-601

**Description**

Prepare Vert.x 5 upgrade.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-feat-upgrade-vertx5-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/ae/gravitee-alert-engine-connectors/3.0.0-feat-upgrade-vertx5-SNAPSHOT/gravitee-alert-engine-connectors-3.0.0-feat-upgrade-vertx5-SNAPSHOT.zip)
  <!-- Version placeholder end -->
