### PR TITLE
feat: add default filters flag to enable default filters in WsTriggerProvider

### DIFF
--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsTriggerProvider.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/WsTriggerProvider.java
@@ -68,19 +68,21 @@ public class WsTriggerProvider extends AbstractTriggerProvider implements Applic
     @Override
     public void register(Trigger trigger) {
         try {
-            final String installationId = context != null ? context.get(Context.CONTEXT_INSTALLATION) : null;
-            if (installationId != null) {
-                // Automatically add a constraint on the installation.
-                final StringCondition installationFilter = StringCondition.equals(Context.CONTEXT_INSTALLATION, installationId).build();
+            if (connectorConfiguration.isDefaultFiltersEnabled()) {
+                final String installationId = context != null ? context.get(Context.CONTEXT_INSTALLATION) : null;
+                if (installationId != null) {
+                    // Automatically add a constraint on the installation.
+                    final StringCondition installationFilter = StringCondition.equals(Context.CONTEXT_INSTALLATION, installationId).build();
 
-                if (trigger.getFilters() == null) {
-                    trigger.setFilters(new ArrayList<>());
-                } else {
-                    // Create a new collection and make sure we will be able to add the filter (ie: get rid of SingletonList, UnmodifiableList, ...).
-                    trigger.setFilters(new ArrayList<>(trigger.getFilters()));
+                    if (trigger.getFilters() == null) {
+                        trigger.setFilters(new ArrayList<>());
+                    } else {
+                        // Create a new collection and make sure we will be able to add the filter (ie: get rid of SingletonList, UnmodifiableList, ...).
+                        trigger.setFilters(new ArrayList<>(trigger.getFilters()));
+                    }
+
+                    trigger.getFilters().add(installationFilter);
                 }
-
-                trigger.getFilters().add(installationFilter);
             }
 
             String value = mapper.writeValueAsString(trigger);

--- a/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/ConnectorConfiguration.java
+++ b/gravitee-alert-engine-connector-ws/src/main/java/io/gravitee/ae/connector/ws/configuration/ConnectorConfiguration.java
@@ -19,15 +19,14 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.ae.connector.ws.Endpoint;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.AbstractEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.Environment;
-import org.springframework.core.env.MapPropertySource;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -43,6 +42,12 @@ public class ConnectorConfiguration {
     public ConnectorConfiguration(Environment environment) {
         this.environment = environment;
     }
+
+    /**
+     * Specifies whether default filters are enabled. Defaults to `true`.
+     */
+    @Value("${alerts.alert-engine.ws.defaultFilters.enabled:true}")
+    private boolean defaultFiltersEnabled;
 
     /**
      * Alert Engine basic auth login.
@@ -626,5 +631,13 @@ public class ConnectorConfiguration {
     public ConnectorConfiguration setProxyHttpsPassword(String proxyHttpsPassword) {
         this.proxyHttpsPassword = proxyHttpsPassword;
         return this;
+    }
+
+    public boolean isDefaultFiltersEnabled() {
+        return defaultFiltersEnabled;
+    }
+
+    public void setDefaultFiltersEnabled(boolean defaultFiltersEnabled) {
+        this.defaultFiltersEnabled = defaultFiltersEnabled;
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/CJ-4045

**Description**

This flag is needed to be able to keep current AE connector feature but allow us to use it in Gravitee Cloud
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.3.0-cj-4045-add-default-filters-flag-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/ae/gravitee-alert-engine-connectors/2.3.0-cj-4045-add-default-filters-flag-SNAPSHOT/gravitee-alert-engine-connectors-2.3.0-cj-4045-add-default-filters-flag-SNAPSHOT.zip)
  <!-- Version placeholder end -->
