### PR TITLE
fix(deps): exclude jackson-core from plugin bundle (APIM-13243)

### DIFF
--- a/gravitee-alert-engine-connector-ws/pom.xml
+++ b/gravitee-alert-engine-connector-ws/pom.xml
@@ -83,6 +83,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-circuit-breaker</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
@@ -91,6 +92,11 @@
         </dependency>
 
         <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-13243

## Description
Fixes GHSA-72hv-8253-57qq: jackson-core was bundled in plugin ZIP via transitive dependency.

Changes (pom.xml only, no breaking changes):
- Add `scope=provided` to `vertx-circuit-breaker` (was pulling jackson-core transitively into plugin ZIP)
- Explicitly declare `jackson-core` with `scope=provided` to prevent bundling in the plugin ZIP

## Grype evidence
Before fix: `gravitee-alert-engine-connectors-ws-3.0.0-alpha.1.zip` reported GHSA-72hv-8253-57qq
After fix: 0 matches

## Notes
- PR #41 targets `master` (wrong branch for this version line) — this PR correctly targets the `alpha` branch where `3.0.0-alpha.1` was produced
- Version bumped from `3.0.0-alpha.1` → `3.0.0-alpha.2`

Made with [Cursor](https://cursor.com)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-fix-apim-13243-alpha-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/ae/gravitee-alert-engine-connectors/3.0.0-fix-apim-13243-alpha-SNAPSHOT/gravitee-alert-engine-connectors-3.0.0-fix-apim-13243-alpha-SNAPSHOT.zip)
  <!-- Version placeholder end -->
