### PR TITLE
fix(deps): mark vertx-circuit-breaker as provided

### DIFF
--- a/gravitee-alert-engine-connector-ws/pom.xml
+++ b/gravitee-alert-engine-connector-ws/pom.xml
@@ -83,6 +83,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-circuit-breaker</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14270

**Description**

Stop bundling Netty in the alert-engine WS connector plugin zip

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.3.1-fix-4-11-x-cve-plugin-netty-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/ae/gravitee-alert-engine-connectors/2.3.1-fix-4-11-x-cve-plugin-netty-SNAPSHOT/gravitee-alert-engine-connectors-2.3.1-fix-4-11-x-cve-plugin-netty-SNAPSHOT.zip)
  <!-- Version placeholder end -->
