### PR TITLE
fix(ae-connectors): bump BOM for Netty CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </modules>
 
     <properties>
-        <gravitee-bom.version>8.2.17</gravitee-bom.version>
+        <gravitee-bom.version>8.3.61</gravitee-bom.version>
         <gravitee-node.version>7.18.0</gravitee-node.version>
         <gravitee-plugin.version>4.7.0</gravitee-plugin.version>
         <gravitee-alert-api.version>2.1.18</gravitee-alert-api.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14270

**Description**

Bump gravitee-bom from 8.2.17 to 8.3.61 (aligned with APIM 4.11.x) so the published gravitee-alert-plugin-connectors-ws zip bundles Netty 4.1.133.Final instead of 4.1.118.

This addresses critical Netty CVEs.

Verified locally: mvn package -DskipTests — ws plugin zip contains Netty 4.1.133.Final (via BOM-managed transitive deps).

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.3.1-fix-4-11-x-cve-bom-bump-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/ae/gravitee-alert-engine-connectors/2.3.1-fix-4-11-x-cve-bom-bump-SNAPSHOT/gravitee-alert-engine-connectors-2.3.1-fix-4-11-x-cve-bom-bump-SNAPSHOT.zip)
  <!-- Version placeholder end -->
